### PR TITLE
Submit comment with Control + Enter (or Command + Enter)

### DIFF
--- a/client/ayon_ui_qt/components/text_box.py
+++ b/client/ayon_ui_qt/components/text_box.py
@@ -19,7 +19,6 @@ from qtpy.QtGui import (
     QTextCursor,
     QTextDocument,
     QTextFrameFormat,
-    QKeySequence
 )
 from qtpy.QtWidgets import (
     QLabel,

--- a/client/ayon_ui_qt/components/text_box.py
+++ b/client/ayon_ui_qt/components/text_box.py
@@ -26,7 +26,6 @@ from qtpy.QtWidgets import (
     QScrollArea,
     QSizePolicy,
     QTextEdit,
-    QShortcut
 )
 
 from .. import get_ayon_style


### PR DESCRIPTION
## Changelog Description

Submit comment with Control + Enter (or Command + Enter)

## Additional review information

Code doesn't feel entirely right, e.g. the keypress event triggering `_on_comment_clicked` sounds weird. So let me know in this codebase how I should be doing this to do it right.

## Testing notes:

1. Allow to submit comment with shortcut