### PR TITLE
Turn up default max size for image cache from 50 MB to 500 MB

### DIFF
--- a/client/ayon_ui_qt/image_cache.py
+++ b/client/ayon_ui_qt/image_cache.py
@@ -35,7 +35,7 @@ class ImageCache:
 
     @classmethod
     def get_instance(
-        cls, cache_path: str | Path | None = None, max_size_in_MB: int = 50
+        cls, cache_path: str | Path | None = None, max_size_in_MB: int = 500
     ) -> ImageCache:
         """Get or create the singleton cache instance.
 


### PR DESCRIPTION
## Changelog Description

Turn up default max size for image cache from 50 MB to 500 MB

## Additional review information

Using the components in desktop review easily takes the full cache and makes it very slow. Increasing the default size here alleviates that for usual use cases.

## Testing notes:

1. Confirm change.