### PR TITLE
Disable not implemented icons: tag versions/tasks and style checklists

### DIFF
--- a/client/ayon_ui_qt/components/text_box.py
+++ b/client/ayon_ui_qt/components/text_box.py
@@ -409,12 +409,15 @@ class AYTextBox(AYContainer):
     format_icons = {
         "fmt_number": "format_list_numbered",
         "fmt_bullet": "format_list_bulleted",
-        "fmt_checklist": "checklist",
+        # TODO: Implement checklist editing and visualizing before enabling
+        # "fmt_checklist": "checklist",
     }
     mention_map = {
         "person": "@",
-        "layers": "@@",
-        "check_circle": "@@@",
+        # TODO: Implement support for version and task mentions in completer
+        #  before enabling these
+        # "layers": "@@",
+        # "check_circle": "@@@",
     }
 
     def __init__(


### PR DESCRIPTION
## Changelog Description

Disable not implemented icons: tag versions/tasks and style checklists

<img width="441" height="142" alt="image" src="https://github.com/user-attachments/assets/05a998bc-64ef-4c9d-a367-cbd5be1e3ac8" />


## Additional review information

Can be enabled again with implementing the functionality for them later.

## Testing notes:

1. Commenting should work in Desktop-review
2. UI should look ok.