### PR TITLE
Implement interactive checklists in comments and editor

### DIFF
--- a/client/ayon_ui_qt/components/checkbox_handler.py
+++ b/client/ayon_ui_qt/components/checkbox_handler.py
@@ -17,6 +17,7 @@ from qtpy.QtGui import (
     QTextDocument,
     QTextFormat,
     QFontMetrics,
+    QTextListFormat,
 )
 from qtpy.QtWidgets import QTextEdit
 
@@ -39,6 +40,10 @@ UNCHECKED_ICON = "radio_button_unchecked"
 UNCHECKED_COLOR = "#FFFFFF"
 CHECKED_ICON = "check_circle"
 CHECKED_COLOR = "#4CAF50"
+
+MD_DIALECT = QTextDocument.MarkdownFeature.MarkdownDialectGitHub
+
+_PH_RE = re.compile(r"^\s*\ufffc ")  # place holder regex
 
 
 @dataclass
@@ -211,17 +216,37 @@ class CheckboxHandler(QObject):
 
                 # Replace checkbox syntax with placeholder
                 # We'll insert the actual object after setting plain text
-                processed_lines.append(f"  \ufffc {text}")
+                processed_lines.append(f"{prefix}\ufffc {text}")
                 checkbox_index += 1
             else:
                 processed_lines.append(line)
 
         # Set the processed text
         processed_text = "\n".join(processed_lines)
-        self._text_edit.setPlainText(processed_text)
+        self._text_edit.setMarkdown(processed_text)
+        self._remove_list_bullets()
 
         # Now insert checkbox objects at placeholder positions
         self._insert_checkbox_objects()
+
+    def _remove_list_bullets(self) -> None:
+        """Remove bullet markers from list blocks containing checkboxes and
+        correct the indentation to match front-end."""
+        doc = self._text_edit.document()
+        processed_lists: set[int] = set()
+
+        block = doc.begin()
+        while block.isValid():
+            text_list = block.textList()
+            if text_list and id(text_list) not in processed_lists:
+                list_key = text_list.item(0).position()
+                if "\ufffc" in block.text():
+                    fmt = text_list.format()
+                    fmt.setStyle(QTextListFormat.Style.ListStyleUndefined)
+                    fmt.setIndent(0)
+                    text_list.setFormat(fmt)
+                    processed_lists.add(list_key)
+            block = block.next()
 
     def _insert_checkbox_objects(self) -> None:
         """Insert checkbox custom objects at placeholder positions."""
@@ -463,33 +488,27 @@ class CheckboxHandler(QObject):
             GitHub-flavored markdown string with checkbox syntax.
         """
         if not self._checkboxes:
-            return self._text_edit.toMarkdown()
+            return self._text_edit.toMarkdown(MD_DIALECT)
 
         # Get current text and replace placeholders with checkbox syntax
         # we use toMarkdown() to make sure the other formatted items have
         # already been dealt with.
-        text = self._text_edit.toMarkdown()
+        text = self._text_edit.toMarkdown(MD_DIALECT)
         lines = text.split("\n")
         result_lines: List[str] = []
 
         checkbox_iter = iter(self._checkboxes)
         current_cb = next(checkbox_iter, None)
-        prev_line_had_checkbox = False
 
         for line in lines:
-            if prev_line_had_checkbox and not line.strip():
-                # Empty line after checkbox: skip
-                prev_line_had_checkbox = False
-                continue
             if "\ufffc" in line and current_cb:
                 # Replace "  \ufffc " with prefix + checkbox syntax
                 checked_char = "x" if current_cb.checked else " "
-                # Remove the two spaces before \ufffc and add the proper prefix
-                line = line.replace(
-                    "  \ufffc ", f"{current_cb.prefix}[{checked_char}] ", 1
+                # Remove the spaces before \ufffc and add the proper prefix
+                line = _PH_RE.sub(
+                    f"{current_cb.prefix}[{checked_char}] ", line, count=1
                 )
                 current_cb = next(checkbox_iter, None)
-                prev_line_had_checkbox = True
             result_lines.append(line)
 
         return "\n".join(result_lines)

--- a/client/ayon_ui_qt/components/checkbox_handler.py
+++ b/client/ayon_ui_qt/components/checkbox_handler.py
@@ -93,7 +93,6 @@ class CheckboxTextObject(QPyTextObject):
         """
         font = doc.defaultFont()
         size = max(font.pointSize() * 1.4, 14)
-        # print(f"size = {size}")
         return QSizeF(size, size)
 
     def drawObject(

--- a/client/ayon_ui_qt/components/checkbox_handler.py
+++ b/client/ayon_ui_qt/components/checkbox_handler.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import List, Tuple
+from typing import List, Optional, Tuple, Union
 
-from qtpy.QtCore import QObject, QRectF, QSizeF, Qt, Signal, QPoint
-from typing import Union
-
-from qtpy.QtCore import QRect
+from qtpy.QtCore import QObject, QPoint, QPointF, QRect, QRectF, QSizeF, Signal
 from qtpy.QtGui import (
     QPainter,
     QPixmap,
@@ -54,6 +51,8 @@ class CheckboxItem:
         text: Text following the checkbox.
         line_number: Line number in the original markdown.
         prefix: Characters before the checkbox (e.g., "- ", "* ").
+        doc_position: Character position of the \\ufffc object in the
+            document, or -1 if not yet placed.
     """
 
     index: int
@@ -61,6 +60,7 @@ class CheckboxItem:
     text: str
     line_number: int
     prefix: str = "- "
+    doc_position: int = field(default=-1)
 
 
 class CheckboxTextObject(QPyTextObject):
@@ -198,7 +198,7 @@ class CheckboxHandler(QObject):
                 text = match.group(3)
                 is_checked = checked_char.lower() == "x"
 
-                # Store checkbox info
+                # Store checkbox info (doc_position filled after insertion)
                 self._checkboxes.append(
                     CheckboxItem(
                         index=checkbox_index,
@@ -239,7 +239,7 @@ class CheckboxHandler(QObject):
             # Find the placeholder character (OBJECT REPLACEMENT CHARACTER)
             pos = text.find("\ufffc", offset)
             if pos == -1:
-                log.warning(f"Could not find placeholder for checkbox {i}")
+                log.warning("Could not find placeholder for checkbox %d", i)
                 continue
 
             # Create format for the checkbox
@@ -256,6 +256,9 @@ class CheckboxHandler(QObject):
             cursor.setPosition(pos + 1, QTextCursor.MoveMode.KeepAnchor)
             cursor.insertText("\ufffc", fmt)
 
+            # Store the document position for fast hit-testing
+            cb.doc_position = pos
+
             offset = pos + 1
 
         cursor.endEditBlock()
@@ -265,7 +268,7 @@ class CheckboxHandler(QObject):
         """Get the checkbox index at the given document position.
 
         Args:
-            pos: Position in the document.
+            pos: Position in the document (one past the \\ufffc char).
 
         Returns:
             Checkbox index if found, None otherwise.
@@ -279,6 +282,60 @@ class CheckboxHandler(QObject):
         if fmt_type == CHECKBOX_FORMAT_TYPE:
             return fmt.property(CHECKBOX_INDEX_PROP)
         return None
+
+    def find_checkbox_at_click(
+        self, click_pos: "QPoint", content_offset: "QPoint | None" = None
+    ) -> Optional[Tuple[bool, Optional[int]]]:
+        """Find the checkbox hit by a viewport click using stored positions.
+
+        Uses the cached ``doc_position`` on each :class:`CheckboxItem`
+        instead of scanning the full document text, making hit-testing O(n)
+        in the number of checkboxes rather than O(len(document)).
+
+        Args:
+            click_pos: Click position in viewport coordinates.
+            content_offset: Optional scroll offset (x, y) as a QPoint.
+                Defaults to (0, 0) when not provided.
+
+        Returns:
+            ``(True, doc_position + 1)`` when the click lands on a checkbox,
+            ``(False, None)`` otherwise.
+        """
+        if not self._checkboxes:
+            return False, None
+
+        doc = self._text_edit.document()
+        ox = content_offset.x() if content_offset else 0
+        oy = content_offset.y() if content_offset else 0
+
+        for cb in self._checkboxes:
+            pos = cb.doc_position
+            if pos < 0:
+                continue
+
+            cursor = QTextCursor(doc)
+            cursor.setPosition(pos)
+            block = cursor.block()
+            block_layout = block.layout()
+
+            if not block_layout:
+                continue
+
+            rel_pos = pos - block.position()
+            line = block_layout.lineForTextPosition(rel_pos)
+            if not line.isValid():
+                continue
+
+            x1 = line.cursorToX(rel_pos)[0]  # type: ignore[index]
+            x2 = line.cursorToX(rel_pos + 1)[0]  # type: ignore[index]
+            y = line.y() + block_layout.position().y()
+            h = line.height()
+
+            rect = QRectF(x1 + ox, y + oy, x2 - x1, h)
+            if rect.contains(QPointF(click_pos)):
+                return True, pos + 1
+
+        return False, None
 
     def toggle_checkbox(self, index: int) -> bool:
         """Toggle a checkbox by its index.
@@ -316,34 +373,88 @@ class CheckboxHandler(QObject):
         doc.blockSignals(True)
 
         try:
-            # Find the checkbox in the document
+            pos = cb.doc_position
+            if pos < 0:
+                # Fall back to scanning if position is unknown
+                text = doc.toPlainText()
+                count = 0
+                for i, char in enumerate(text):
+                    if char == "\ufffc":
+                        if count == index:
+                            pos = i
+                            break
+                        count += 1
+
+            if pos < 0:
+                log.warning(
+                    "Cannot find document position for checkbox %d", index
+                )
+                return
+
             cursor = QTextCursor(doc)
-            text = doc.toPlainText()
+            cursor.setPosition(pos)
+            cursor.setPosition(pos + 1, QTextCursor.MoveMode.KeepAnchor)
 
-            # Count object replacement characters to find the right one
-            count = 0
-            for i, char in enumerate(text):
-                if char == "\ufffc":
-                    if count == index:
-                        # Found it - update the format
-                        cursor.setPosition(i)
-                        cursor.setPosition(
-                            i + 1, QTextCursor.MoveMode.KeepAnchor
-                        )
+            fmt = QTextCharFormat()
+            fmt.setObjectType(CHECKBOX_FORMAT_TYPE)
+            fmt.setProperty(CHECKBOX_CHECKED_PROP, cb.checked)
+            fmt.setProperty(CHECKBOX_INDEX_PROP, cb.index)
+            fmt.setVerticalAlignment(
+                QTextCharFormat.VerticalAlignment.AlignBaseline
+            )
 
-                        fmt = QTextCharFormat()
-                        fmt.setObjectType(CHECKBOX_FORMAT_TYPE)
-                        fmt.setProperty(CHECKBOX_CHECKED_PROP, cb.checked)
-                        fmt.setProperty(CHECKBOX_INDEX_PROP, cb.index)
-                        fmt.setVerticalAlignment(
-                            QTextCharFormat.VerticalAlignment.AlignBaseline
-                        )
-
-                        cursor.setCharFormat(fmt)
-                        break
-                    count += 1
+            cursor.setCharFormat(fmt)
         finally:
             doc.blockSignals(False)
+
+    def add_checkbox(
+        self,
+        checked: bool = False,
+        prefix: str = "- ",
+        doc_position: int = -1,
+    ) -> CheckboxItem:
+        """Append a new checkbox to the tracked list.
+
+        This is the public API for adding a checkbox programmatically
+        (e.g. when the user presses Enter on a checkbox line or clicks
+        the checklist toolbar button).  The caller is responsible for
+        inserting the actual ``\\ufffc`` character into the document and
+        then updating :attr:`CheckboxItem.doc_position`.
+
+        Args:
+            checked: Initial checked state.
+            prefix: Markdown list prefix (e.g. ``"- "``).
+            doc_position: Document character position of the ``\\ufffc``
+                object, or ``-1`` if not yet known.
+
+        Returns:
+            The newly created :class:`CheckboxItem`.
+        """
+        new_index = len(self._checkboxes)
+        item = CheckboxItem(
+            index=new_index,
+            checked=checked,
+            text="",
+            line_number=-1,
+            prefix=prefix,
+            doc_position=doc_position,
+        )
+        self._checkboxes.append(item)
+        return item
+
+    def remove_last_checkbox(self) -> bool:
+        """Remove the last checkbox from the tracked list.
+
+        Used when the user presses Enter on an empty checkbox line to
+        terminate the list.
+
+        Returns:
+            True if a checkbox was removed, False if the list was empty.
+        """
+        if not self._checkboxes:
+            return False
+        self._checkboxes.pop()
+        return True
 
     def to_markdown(self) -> str:
         """Reconstruct markdown with current checkbox states.
@@ -352,22 +463,33 @@ class CheckboxHandler(QObject):
             GitHub-flavored markdown string with checkbox syntax.
         """
         if not self._checkboxes:
-            return self._text_edit.toPlainText()
+            return self._text_edit.toMarkdown()
 
         # Get current text and replace placeholders with checkbox syntax
-        text = self._text_edit.toPlainText()
+        # we use toMarkdown() to make sure the other formatted items have
+        # already been dealt with.
+        text = self._text_edit.toMarkdown()
         lines = text.split("\n")
         result_lines: List[str] = []
 
         checkbox_iter = iter(self._checkboxes)
         current_cb = next(checkbox_iter, None)
+        prev_line_had_checkbox = False
 
         for line in lines:
+            if prev_line_had_checkbox and not line.strip():
+                # Empty line after checkbox: skip
+                prev_line_had_checkbox = False
+                continue
             if "\ufffc" in line and current_cb:
-                # Replace placeholder with checkbox syntax
+                # Replace "  \ufffc " with prefix + checkbox syntax
                 checked_char = "x" if current_cb.checked else " "
-                line = line.replace("\ufffc", f"[{checked_char}]", 1)
+                # Remove the two spaces before \ufffc and add the proper prefix
+                line = line.replace(
+                    "  \ufffc ", f"{current_cb.prefix}[{checked_char}] ", 1
+                )
                 current_cb = next(checkbox_iter, None)
+                prev_line_had_checkbox = True
             result_lines.append(line)
 
         return "\n".join(result_lines)
@@ -387,7 +509,7 @@ class CheckboxHandler(QObject):
         Returns:
             True if there are checkboxes, False otherwise.
         """
-        return len(self._checkboxes) > 0
+        return bool(self._checkboxes)
 
     @staticmethod
     def contains_checkboxes(markdown: str) -> bool:

--- a/client/ayon_ui_qt/components/checkbox_handler.py
+++ b/client/ayon_ui_qt/components/checkbox_handler.py
@@ -1,0 +1,402 @@
+"""Checkbox handler for markdown checkboxes in QTextEdit."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+from qtpy.QtCore import QObject, QRectF, QSizeF, Qt, Signal, QPoint
+from typing import Union
+
+from qtpy.QtCore import QRect
+from qtpy.QtGui import (
+    QPainter,
+    QPixmap,
+    QPyTextObject,
+    QTextCharFormat,
+    QTextCursor,
+    QTextDocument,
+    QTextFormat,
+    QFontMetrics,
+)
+from qtpy.QtWidgets import QTextEdit
+
+try:
+    from qtmaterialsymbols import get_icon  # type: ignore
+except ImportError:
+    from ..vendor.qtmaterialsymbols import get_icon
+
+log = logging.getLogger(__name__)
+
+# Custom format type for checkboxes (must be unique)
+CHECKBOX_FORMAT_TYPE = QTextFormat.ObjectTypes.UserObject + 1
+
+# Property keys for checkbox data stored in QTextCharFormat
+CHECKBOX_CHECKED_PROP = 1
+CHECKBOX_INDEX_PROP = 2
+
+# Icon configuration
+UNCHECKED_ICON = "radio_button_unchecked"
+UNCHECKED_COLOR = "#FFFFFF"
+CHECKED_ICON = "check_circle"
+CHECKED_COLOR = "#4CAF50"
+
+
+@dataclass
+class CheckboxItem:
+    """Represents a checkbox item in the document.
+
+    Attributes:
+        index: Unique index of the checkbox.
+        checked: Whether the checkbox is checked.
+        text: Text following the checkbox.
+        line_number: Line number in the original markdown.
+        prefix: Characters before the checkbox (e.g., "- ", "* ").
+    """
+
+    index: int
+    checked: bool
+    text: str
+    line_number: int
+    prefix: str = "- "
+
+
+class CheckboxTextObject(QPyTextObject):
+    """Custom text object for rendering checkbox icons in QTextDocument.
+
+    Uses Material icons to render checkboxes:
+    - Unchecked: white radio_button_unchecked
+    - Checked: green check_circle
+    """
+
+    def __init__(self, parent: QObject | None = None):
+        super().__init__(parent)
+        self._icon_cache: dict[bool, QPixmap] = {}
+
+    def intrinsicSize(
+        self,
+        doc: QTextDocument,
+        posInDocument: int,
+        format: QTextFormat,
+    ) -> QSizeF:
+        """Return the size of the checkbox icon.
+
+        Args:
+            doc: The document containing the object.
+            posInDocument: Position in the document.
+            format: The text format of the object.
+
+        Returns:
+            Size of the checkbox icon based on font size.
+        """
+        font = doc.defaultFont()
+        size = max(font.pointSize() * 1.4, 14)
+        # print(f"size = {size}")
+        return QSizeF(size, size)
+
+    def drawObject(
+        self,
+        painter: QPainter,
+        rect: Union[QRectF, QRect],
+        doc: QTextDocument,
+        posInDocument: int,
+        format: QTextFormat,
+    ) -> None:
+        """Draw the checkbox icon.
+
+        Args:
+            painter: The painter to draw with.
+            rect: The rectangle to draw in.
+            doc: The document containing the object.
+            posInDocument: Position in the document.
+            format: The text format containing checkbox state.
+        """
+        is_checked = format.property(CHECKBOX_CHECKED_PROP)
+
+        if is_checked:
+            icon = get_icon(CHECKED_ICON, color=CHECKED_COLOR)
+        else:
+            icon = get_icon(UNCHECKED_ICON, color=UNCHECKED_COLOR)
+
+        size = int(min(rect.width(), rect.height()))
+        pixmap = icon.pixmap(size, size)
+
+        # Vertically center the icon relative to text ascent
+        font_metrics = QFontMetrics(doc.defaultFont())
+        ascent = font_metrics.ascent()
+        y_offset = (ascent - size) // 3
+        draw_point = rect.topLeft().toPoint() + QPoint(0, -y_offset)
+
+        painter.drawPixmap(draw_point, pixmap)
+
+
+class CheckboxHandler(QObject):
+    """Handles checkbox parsing, rendering, and state management.
+
+    This class manages:
+    - Parsing markdown to extract checkbox items
+    - Registering custom text objects for checkbox rendering
+    - Tracking checkbox state and positions
+    - Converting back to markdown format
+
+    Signals:
+        checklist_changed: Emitted when any checkbox state changes.
+    """
+
+    checklist_changed = Signal()
+
+    # GitHub-flavored markdown checkbox patterns
+    # Matches: - [ ] text, - [x] text, * [ ] text, * [X] text, + [ ] text
+    CHECKBOX_PATTERN = re.compile(
+        r"^(\s*[-*+]\s+)\[([xX ])\]\s*(.*)$", re.MULTILINE
+    )
+
+    def __init__(self, text_edit: QTextEdit, parent: QObject | None = None):
+        """Initialize the checkbox handler.
+
+        Args:
+            text_edit: The QTextEdit widget to manage checkboxes for.
+            parent: Optional parent QObject.
+        """
+        super().__init__(parent)
+        self._text_edit = text_edit
+        self._checkboxes: List[CheckboxItem] = []
+        self._checkbox_object: CheckboxTextObject | None = None
+        self._original_markdown: str = ""
+        self._register_handler()
+
+    def _register_handler(self) -> None:
+        """Register the custom checkbox text object with the document."""
+        self._checkbox_object = CheckboxTextObject(self)
+        doc = self._text_edit.document()
+        doc_layout = doc.documentLayout()
+        doc_layout.registerHandler(CHECKBOX_FORMAT_TYPE, self._checkbox_object)
+
+    def parse_and_render(self, markdown: str) -> None:
+        """Parse markdown and render checkboxes in the document.
+
+        Extracts checkbox items from markdown, stores their state,
+        and renders them as custom text objects with icons.
+
+        Args:
+            markdown: The markdown string containing checkboxes.
+        """
+        self._original_markdown = markdown
+        self._checkboxes.clear()
+
+        # Find all checkbox patterns
+        lines = markdown.split("\n")
+        processed_lines: List[str] = []
+        checkbox_index = 0
+
+        for line_num, line in enumerate(lines):
+            match = self.CHECKBOX_PATTERN.match(line)
+            if match:
+                prefix = match.group(1)
+                checked_char = match.group(2)
+                text = match.group(3)
+                is_checked = checked_char.lower() == "x"
+
+                # Store checkbox info
+                self._checkboxes.append(
+                    CheckboxItem(
+                        index=checkbox_index,
+                        checked=is_checked,
+                        text=text,
+                        line_number=line_num,
+                        prefix=prefix,
+                    )
+                )
+
+                # Replace checkbox syntax with placeholder
+                # We'll insert the actual object after setting plain text
+                processed_lines.append(f"  \ufffc {text}")
+                checkbox_index += 1
+            else:
+                processed_lines.append(line)
+
+        # Set the processed text
+        processed_text = "\n".join(processed_lines)
+        self._text_edit.setPlainText(processed_text)
+
+        # Now insert checkbox objects at placeholder positions
+        self._insert_checkbox_objects()
+
+    def _insert_checkbox_objects(self) -> None:
+        """Insert checkbox custom objects at placeholder positions."""
+        doc = self._text_edit.document()
+        doc.blockSignals(True)
+
+        cursor = QTextCursor(doc)
+        cursor.beginEditBlock()
+
+        # Find all placeholder characters and replace with checkbox objects
+        text = doc.toPlainText()
+        offset = 0
+
+        for i, cb in enumerate(self._checkboxes):
+            # Find the placeholder character (OBJECT REPLACEMENT CHARACTER)
+            pos = text.find("\ufffc", offset)
+            if pos == -1:
+                log.warning(f"Could not find placeholder for checkbox {i}")
+                continue
+
+            # Create format for the checkbox
+            fmt = QTextCharFormat()
+            fmt.setObjectType(CHECKBOX_FORMAT_TYPE)
+            fmt.setProperty(CHECKBOX_CHECKED_PROP, cb.checked)
+            fmt.setProperty(CHECKBOX_INDEX_PROP, cb.index)
+            fmt.setVerticalAlignment(
+                QTextCharFormat.VerticalAlignment.AlignBaseline
+            )
+
+            # Select and replace the placeholder
+            cursor.setPosition(pos)
+            cursor.setPosition(pos + 1, QTextCursor.MoveMode.KeepAnchor)
+            cursor.insertText("\ufffc", fmt)
+
+            offset = pos + 1
+
+        cursor.endEditBlock()
+        doc.blockSignals(False)
+
+    def get_checkbox_at_position(self, pos: int) -> int | None:
+        """Get the checkbox index at the given document position.
+
+        Args:
+            pos: Position in the document.
+
+        Returns:
+            Checkbox index if found, None otherwise.
+        """
+        doc = self._text_edit.document()
+        cursor = QTextCursor(doc)
+        cursor.setPosition(pos)
+        fmt = cursor.charFormat()
+
+        if fmt.objectType() == CHECKBOX_FORMAT_TYPE:
+            return fmt.property(CHECKBOX_INDEX_PROP)
+        return None
+
+    def toggle_checkbox(self, index: int) -> bool:
+        """Toggle a checkbox by its index.
+
+        Args:
+            index: The index of the checkbox to toggle.
+
+        Returns:
+            True if the checkbox was toggled, False otherwise.
+        """
+        if not 0 <= index < len(self._checkboxes):
+            return False
+
+        # Toggle the state
+        self._checkboxes[index].checked = not self._checkboxes[index].checked
+
+        # Update the document
+        self._update_checkbox_in_document(index)
+
+        # Emit signal
+        self.checklist_changed.emit()
+        return True
+
+    def _update_checkbox_in_document(self, index: int) -> None:
+        """Update a single checkbox display in the document.
+
+        Args:
+            index: The index of the checkbox to update.
+        """
+        doc = self._text_edit.document()
+        cb = self._checkboxes[index]
+
+        # Block signals to prevent triggering format_comment_on_change
+        # which would clear all formatting including checkboxes
+        doc.blockSignals(True)
+
+        try:
+            # Find the checkbox in the document
+            cursor = QTextCursor(doc)
+            text = doc.toPlainText()
+
+            # Count object replacement characters to find the right one
+            count = 0
+            for i, char in enumerate(text):
+                if char == "\ufffc":
+                    if count == index:
+                        # Found it - update the format
+                        cursor.setPosition(i)
+                        cursor.setPosition(
+                            i + 1, QTextCursor.MoveMode.KeepAnchor
+                        )
+
+                        fmt = QTextCharFormat()
+                        fmt.setObjectType(CHECKBOX_FORMAT_TYPE)
+                        fmt.setProperty(CHECKBOX_CHECKED_PROP, cb.checked)
+                        fmt.setProperty(CHECKBOX_INDEX_PROP, cb.index)
+                        fmt.setVerticalAlignment(
+                            QTextCharFormat.VerticalAlignment.AlignBaseline
+                        )
+
+                        cursor.setCharFormat(fmt)
+                        break
+                    count += 1
+        finally:
+            doc.blockSignals(False)
+
+    def to_markdown(self) -> str:
+        """Reconstruct markdown with current checkbox states.
+
+        Returns:
+            GitHub-flavored markdown string with checkbox syntax.
+        """
+        if not self._checkboxes:
+            return self._text_edit.toPlainText()
+
+        # Get current text and replace placeholders with checkbox syntax
+        text = self._text_edit.toPlainText()
+        lines = text.split("\n")
+        result_lines: List[str] = []
+
+        checkbox_iter = iter(self._checkboxes)
+        current_cb = next(checkbox_iter, None)
+
+        for line in lines:
+            if "\ufffc" in line and current_cb:
+                # Replace placeholder with checkbox syntax
+                checked_char = "x" if current_cb.checked else " "
+                line = line.replace("\ufffc", f"[{checked_char}]", 1)
+                current_cb = next(checkbox_iter, None)
+            result_lines.append(line)
+
+        return "\n".join(result_lines)
+
+    @property
+    def checkboxes(self) -> List[CheckboxItem]:
+        """Get the list of checkbox items.
+
+        Returns:
+            List of CheckboxItem objects.
+        """
+        return self._checkboxes.copy()
+
+    def has_checkboxes(self) -> bool:
+        """Check if the document contains any checkboxes.
+
+        Returns:
+            True if there are checkboxes, False otherwise.
+        """
+        return len(self._checkboxes) > 0
+
+    @staticmethod
+    def contains_checkboxes(markdown: str) -> bool:
+        """Check if markdown text contains checkbox syntax.
+
+        Args:
+            markdown: The markdown string to check.
+
+        Returns:
+            True if checkbox syntax is found, False otherwise.
+        """
+        return bool(CheckboxHandler.CHECKBOX_PATTERN.search(markdown))

--- a/client/ayon_ui_qt/components/checkbox_handler.py
+++ b/client/ayon_ui_qt/components/checkbox_handler.py
@@ -467,6 +467,18 @@ class CheckboxHandler(QObject):
         self._checkboxes.append(item)
         return item
 
+    def remove_checkbox(self, index: int) -> None:
+        """Remove a checkbox from the tracked list.
+
+        Args:
+            index: The index of the checkbox to remove.
+        """
+        if 0 <= index < len(self._checkboxes):
+            self._checkboxes.pop(index)
+            # Update indices of remaining checkboxes
+            for i, cb in enumerate(self._checkboxes[index:], start=index):
+                cb.index = i
+
     def remove_last_checkbox(self) -> bool:
         """Remove the last checkbox from the tracked list.
 

--- a/client/ayon_ui_qt/components/checkbox_handler.py
+++ b/client/ayon_ui_qt/components/checkbox_handler.py
@@ -275,8 +275,9 @@ class CheckboxHandler(QObject):
         cursor = QTextCursor(doc)
         cursor.setPosition(pos)
         fmt = cursor.charFormat()
+        fmt_type = fmt.objectType()
 
-        if fmt.objectType() == CHECKBOX_FORMAT_TYPE:
+        if fmt_type == CHECKBOX_FORMAT_TYPE:
             return fmt.property(CHECKBOX_INDEX_PROP)
         return None
 

--- a/client/ayon_ui_qt/components/comment.py
+++ b/client/ayon_ui_qt/components/comment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import tempfile
 from pathlib import Path
 
@@ -17,6 +18,8 @@ from qtpy.QtGui import (
     QPainter,
     QPaintEvent,
     QPixmap,
+    QTextCharFormat,
+    QTextCursor,
     QTextDocument,
 )
 from qtpy.QtWidgets import (
@@ -39,7 +42,12 @@ from ..image_cache import ImageCache
 from ..utils import color_blend
 from ..variants import QTextEditVariants
 from .buttons import AYButton
-from .checkbox_handler import CHECKBOX_FORMAT_TYPE, CheckboxHandler
+from .checkbox_handler import (
+    CHECKBOX_CHECKED_PROP,
+    CHECKBOX_FORMAT_TYPE,
+    CHECKBOX_INDEX_PROP,
+    CheckboxHandler,
+)
 from .combo_box import ALL_STATUSES
 from .comment_completion import (
     apply_code_block_backgrounds,
@@ -400,11 +408,100 @@ class AYCommentField(AYTextEdit):
             -self.verticalScrollBar().value(),
         )
 
+    def _insert_checkbox_at_cursor(self, cursor: QTextCursor) -> None:
+        """Insert a new unchecked checkbox object at the cursor position.
+
+        Inserts the custom checkbox object character (``\\ufffc``), and a
+        trailing space, then records the document position on the
+        :class:`CheckboxItem` for fast hit-testing.
+        The checkbox handler must already be initialised via
+        :meth:`_setup_checkbox_handler`.
+
+        Args:
+            cursor: Cursor at the insertion point; advanced past the
+                inserted characters on return.
+        """
+        assert self._checkbox_handler is not None
+        new_item = self._checkbox_handler.add_checkbox()
+        fmt = QTextCharFormat()
+        fmt.setObjectType(CHECKBOX_FORMAT_TYPE)
+        fmt.setProperty(CHECKBOX_CHECKED_PROP, False)
+        fmt.setProperty(CHECKBOX_INDEX_PROP, new_item.index)
+        fmt.setVerticalAlignment(
+            QTextCharFormat.VerticalAlignment.AlignBaseline
+        )
+        new_item.doc_position = cursor.position()
+        cursor.insertText("\ufffc", fmt)
+        cursor.insertText(" ")
+
     def keyPressEvent(self, event) -> None:
         """Handle key press events for completer."""
         if on_completer_key_press(self, event):
             event.accept()
             return
+
+        # Auto-continue checkbox on Enter
+        if (
+            event.key() in {Qt.Key.Key_Return, Qt.Key.Key_Enter}
+            and self._checkbox_handler
+            and self._checkbox_handler.has_checkboxes()
+        ):
+            cursor = self.textCursor()
+            block_text = cursor.block().text()
+
+            if "\ufffc" in block_text:
+                # Extract text after the checkbox object char
+                parts = block_text.split("\ufffc", 1)
+                after_checkbox = parts[1].strip() if len(parts) > 1 else ""
+                position_in_block = cursor.positionInBlock()
+                token_pos_in_block = block_text.index("\ufffc")
+                token_pos = (
+                    cursor.position() - position_in_block + token_pos_in_block
+                )
+                cb_index = self._checkbox_handler.get_checkbox_at_position(
+                    token_pos
+                )
+
+                if not after_checkbox:
+                    self._suppress_formatting = True
+                    try:
+                        # Empty checkbox line → end the list
+                        # Remove the checkbox content from current block
+                        cursor.movePosition(
+                            QTextCursor.MoveOperation.StartOfBlock,
+                            QTextCursor.MoveMode.MoveAnchor,
+                        )
+                        cursor.movePosition(
+                            QTextCursor.MoveOperation.EndOfBlock,
+                            QTextCursor.MoveMode.KeepAnchor,
+                        )
+                        cursor.removeSelectedText()
+                        # Remove the last checkbox from handler
+                        if cb_index is not None:
+                            self._checkbox_handler.remove_checkbox(cb_index)
+                    finally:
+                        self._suppress_formatting = False
+                    # Insert a plain newline
+                    super().keyPressEvent(event)
+                    return
+
+                # Non-empty checkbox line → insert new checkbox
+                event.accept()
+                self._suppress_formatting = True
+
+                try:
+                    cursor.beginEditBlock()
+                    cursor.movePosition(QTextCursor.MoveOperation.EndOfBlock)
+                    cursor.insertBlock()
+                    self._insert_checkbox_at_cursor(cursor)
+                    cursor.endEditBlock()
+                except Exception as err:
+                    logging.debug("Error inserting checkbox: %s", err)
+                finally:
+                    self._suppress_formatting = False
+                self.setTextCursor(cursor)
+                return
+
         super().keyPressEvent(event)
 
     def _is_checkbox_at_cursor(

--- a/client/ayon_ui_qt/components/comment.py
+++ b/client/ayon_ui_qt/components/comment.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from pathlib import Path
 import tempfile
+from pathlib import Path
 
-from qtpy.QtCore import QEvent, QPoint, Qt, Signal, QSize, QRect
+from qtpy.QtCore import QEvent, QPoint, QRect, QSize, Qt, Signal
 from qtpy.QtGui import (
     QColor,
     QEnterEvent,
     QPainter,
     QPaintEvent,
     QPixmap,
+    QTextCursor,
     QTextDocument,
 )
 from qtpy.QtWidgets import (
@@ -28,9 +29,11 @@ from ..data_models import (
     User,
     VersionPublishModel,
 )
+from ..image_cache import ImageCache
 from ..utils import color_blend
 from ..variants import QTextEditVariants
 from .buttons import AYButton
+from .checkbox_handler import CHECKBOX_FORMAT_TYPE, CheckboxHandler
 from .combo_box import ALL_STATUSES
 from .comment_completion import (
     apply_web_markdown_formatting,
@@ -45,7 +48,6 @@ from .label import AYLabel, get_icon
 from .layouts import AYHBoxLayout, AYVBoxLayout
 from .text_edit import AYTextEdit
 from .user_image import AYUserImage
-from ..image_cache import ImageCache
 
 # STATUS ---------------------------------------------------------------------
 
@@ -191,9 +193,17 @@ MD_DIALECT = QTextDocument.MarkdownFeature.MarkdownDialectGitHub
 
 
 class AYCommentField(AYTextEdit):
-    """Text field for comment display with markdown support."""
+    """Text field for comment display with markdown and checkbox support.
+
+    Supports GitHub-flavored markdown checkboxes (- [ ] and - [x]) that
+    render with Material icons and can be toggled even in read-only mode.
+
+    Signals:
+        checklist_changed: Emitted when a checkbox state changes.
+    """
 
     Variants = QTextEditVariants
+    checklist_changed = Signal()
 
     def __init__(
         self,
@@ -212,10 +222,14 @@ class AYCommentField(AYTextEdit):
         self._user_list: list[User] = user_list or []
         self._data = model
         self._bg_color = None
+        self._checkbox_handler: CheckboxHandler | None = None
 
         super().__init__(*args, variant=variant, **kwargs)
         self.setAutoFormatting(QTextEdit.AutoFormattingFlag.AutoAll)
         self.setSizeAdjustPolicy(QTextEdit.SizeAdjustPolicy.AdjustToContents)
+        # Enable mouse tracking on viewport to receive mouseMoveEvent
+        # self.setMouseTracking(True)
+        self.viewport().setMouseTracking(True)
         self.set_markdown(text)
 
         # configure
@@ -257,15 +271,26 @@ class AYCommentField(AYTextEdit):
         return self._bg_color
 
     def set_markdown(self, md: str) -> None:
-        """Set markdown content, supporting both standard markdown and web markdown.
+        """Set markdown content with checkbox and web markdown support.
 
-        If text contains web markdown syntax (text\\n----, **bold**, _italic_, [link](url), `code`),
-        it will be parsed and formatted accordingly with syntax removed.
-        Otherwise, uses standard QTextDocument markdown.
+        Supports:
+        - GitHub-flavored markdown checkboxes (- [ ] and - [x])
+        - Web markdown syntax (text\\n----, **bold**, _italic_, [link](url))
+        - Standard QTextDocument markdown
 
         Args:
             md: Markdown text to display
         """
+        # Check for checkboxes first
+        if CheckboxHandler.contains_checkboxes(md):
+            self._setup_checkbox_handler()
+            # Handler is guaranteed to exist after _setup_checkbox_handler
+            assert self._checkbox_handler is not None
+            self._checkbox_handler.parse_and_render(md)
+            if self._read_only:
+                self._adjust_height_to_content()
+            return
+
         # Check if text contains web markdown syntax
         has_web_markdown = any(
             pattern in md for pattern in ["\n----", "**", "_", "[", "`"]
@@ -278,6 +303,20 @@ class AYCommentField(AYTextEdit):
             # Use standard markdown
             self.document().setMarkdown(md, MD_DIALECT)
 
+        if self._read_only:
+            self._adjust_height_to_content()
+
+    def _setup_checkbox_handler(self) -> None:
+        """Initialize checkbox handler if not already done."""
+        if self._checkbox_handler is None:
+            self._checkbox_handler = CheckboxHandler(self)
+            self._checkbox_handler.checklist_changed.connect(
+                self._on_checklist_changed
+            )
+
+    def _on_checklist_changed(self) -> None:
+        """Handle checkbox state changes."""
+        self.checklist_changed.emit()
         if self._read_only:
             self._adjust_height_to_content()
 
@@ -294,6 +333,16 @@ class AYCommentField(AYTextEdit):
         self.setReadOnly(self._read_only)
 
     def as_markdown(self) -> str:
+        """Get the content as GitHub-flavored markdown.
+
+        If the field contains checkboxes, returns the markdown with
+        checkbox syntax (- [ ] and - [x]) reflecting current state.
+
+        Returns:
+            Markdown string.
+        """
+        if self._checkbox_handler and self._checkbox_handler.has_checkboxes():
+            return self._checkbox_handler.to_markdown()
         return self.document().toMarkdown(MD_DIALECT)
 
     def _on_text_changed(self) -> None:
@@ -339,14 +388,55 @@ class AYCommentField(AYTextEdit):
             return
         super().keyPressEvent(event)
 
-    def mousePressEvent(self, event) -> None:
-        """Handle mouse press events to open links only in read-only mode."""
-        # Only handle link clicks in read-only mode (display comments)
-        if self.isReadOnly():
-            # Get the character at the click position
-            cursor = self.cursorForPosition(event.pos())
-            char_format = cursor.charFormat()
+    def _is_checkbox_at_cursor(self, cursor) -> tuple[bool, int | None]:
+        """Check if a checkbox is at or adjacent to the cursor position.
 
+        Args:
+            cursor: QTextCursor from cursorForPosition.
+
+        Returns:
+            Tuple of (is_checkbox, document_position_of_checkbox).
+        """
+        doc = self.document()
+        pos = cursor.position()
+        for check_pos in (pos, pos - 1, pos + 1):
+            if not (0 <= check_pos < doc.characterCount()):
+                continue
+            tmp = QTextCursor(doc)
+            tmp.setPosition(check_pos)
+            tmp.setPosition(check_pos - 1, QTextCursor.MoveMode.KeepAnchor)
+            if tmp.charFormat().objectType() == CHECKBOX_FORMAT_TYPE:
+                return True, check_pos
+        return False, None
+
+    def mousePressEvent(self, event) -> None:
+        """Handle mouse press events for checkboxes and links.
+
+        Checkboxes can be toggled even in read-only mode.
+        Links are opened only in read-only mode.
+        """
+        # Get the character at the click position
+        cursor = self.cursorForPosition(event.pos())
+        char_format = cursor.charFormat()
+
+        # Check if clicked on a checkbox (works in both modes)
+        is_cb, _ = self._is_checkbox_at_cursor(cursor)
+        # if char_format.objectType() == CHECKBOX_FORMAT_TYPE:
+        if is_cb:
+            if self._checkbox_handler:
+                # Get cursor position to find which checkbox
+                pos = cursor.position()
+                checkbox_idx = self._checkbox_handler.get_checkbox_at_position(
+                    pos
+                )
+                if checkbox_idx is not None:
+                    self._checkbox_handler.toggle_checkbox(checkbox_idx)
+                    self.viewport().update()
+                    event.accept()
+                    return
+
+        # Handle link clicks only in read-only mode (display comments)
+        if self.isReadOnly():
             # Check if the clicked text is a link (has anchor href)
             if char_format.isAnchor() and char_format.anchorHref():
                 import webbrowser
@@ -359,19 +449,25 @@ class AYCommentField(AYTextEdit):
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event) -> None:
-        """Change cursor to hand when hovering over links in read-only mode."""
-        # Only show hand cursor in read-only mode (display comments)
-        if self.isReadOnly():
-            cursor = self.cursorForPosition(event.pos())
-            char_format = cursor.charFormat()
+        """Change cursor to arrow when hovering over checkboxes, hand for links."""
+        cursor = self.cursorForPosition(event.pos())
+        char_format = cursor.charFormat()
+        # print(char_format.objectType())
 
-            # Show hand cursor only for actual links with href
+        # Show arrow cursor for checkboxes (in any mode)
+        if char_format.objectType() == CHECKBOX_FORMAT_TYPE:
+            self.viewport().setCursor(Qt.CursorShape.ArrowCursor)
+            super().mouseMoveEvent(event)
+            return
+
+        # Show hand cursor for links (only in read-only mode)
+        if self.isReadOnly():
             if char_format.isAnchor() and char_format.anchorHref():
-                self.setCursor(Qt.CursorShape.PointingHandCursor)
+                self.viewport().setCursor(Qt.CursorShape.PointingHandCursor)
             else:
-                self.setCursor(Qt.CursorShape.IBeamCursor)
+                self.viewport().setCursor(Qt.CursorShape.ArrowCursor)
         else:
-            self.setCursor(Qt.CursorShape.IBeamCursor)
+            self.viewport().setCursor(Qt.CursorShape.IBeamCursor)
 
         super().mouseMoveEvent(event)
 
@@ -436,9 +532,7 @@ class AYImageAttachment(QLabel):
                 Qt.TransformationMode.SmoothTransformation,
             )
             tmp_dir = Path(tempfile.mkdtemp())
-            tmp_file_path = (
-                tmp_dir / f"{thumb_path.name}.thumb.png"
-            )
+            tmp_file_path = tmp_dir / f"{thumb_path.name}.thumb.png"
             scaled_pixmap.save(str(tmp_file_path), quality=75)
             return tmp_file_path
 
@@ -917,6 +1011,31 @@ if __name__ == "__main__":
                 )
             )
         )
+
+        # Test checkbox functionality
+        checklist_comment = AYComment(
+            data=CommentModel(
+                user_full_name="Task Manager",
+                comment=(
+                    "Review checklist:\n"
+                    "- [x] Check animation timing\n"
+                    "- [ ] Review color grading\n"
+                    "- [ ] Verify audio sync\n"
+                    "- [x] Approve final render"
+                ),
+                category="Checklist",
+                category_color="#5599ff",
+            )
+        )
+        # Connect to log checkbox changes
+        checklist_comment.text_field.checklist_changed.connect(
+            lambda: print(
+                "Checkbox changed! New markdown:\n"
+                + checklist_comment.text_field.as_markdown()
+            )
+        )
+        w.add_widget(checklist_comment)
+
         w.add_widget(AYTextBox(num_lines=3, variant=AYTextBox.Variants.High))
         return w
 

--- a/client/ayon_ui_qt/components/comment.py
+++ b/client/ayon_ui_qt/components/comment.py
@@ -751,6 +751,8 @@ class AYComment(AYContainer):
             self.set_comment_category()
             self._build_image_attachments()
 
+        self.text_field.checklist_changed.connect(self._on_checklist_changed)
+
     def _build_top_bar(self):
         self.user_icon = AYUserImage(
             parent=self,
@@ -1003,6 +1005,11 @@ class AYComment(AYContainer):
                 image_attachment._image_path = ic.get_path(f"act_{file_id}")
             if image_attachment:
                 image_attachment._load_thumbnail()
+
+    def _on_checklist_changed(self):
+        md = self.text_field.as_markdown()
+        self._data.comment = md
+        self.comment_edited.emit(self._data)
 
 
 if __name__ == "__main__":

--- a/client/ayon_ui_qt/components/comment.py
+++ b/client/ayon_ui_qt/components/comment.py
@@ -469,6 +469,14 @@ class AYCommentField(AYTextEdit):
 
         return False, None
 
+    def mouseDoubleClickEvent(self, event) -> None:
+        """Prevent text selection when double-clicking checkboxes."""
+        is_cb, cb_pos = self._is_checkbox_at_cursor(event.pos())
+        if is_cb and cb_pos is not None:
+            event.accept()
+            return
+        super().mouseDoubleClickEvent(event)
+
     def mousePressEvent(self, event) -> None:
         """Handle mouse press events for checkboxes and links.
 

--- a/client/ayon_ui_qt/components/comment.py
+++ b/client/ayon_ui_qt/components/comment.py
@@ -8,7 +8,6 @@ from qtpy.QtCore import (
     QPoint,
     QPointF,
     QRect,
-    QRectF,
     Qt,
     Signal,
 )
@@ -18,7 +17,6 @@ from qtpy.QtGui import (
     QPainter,
     QPaintEvent,
     QPixmap,
-    QTextCursor,
     QTextDocument,
 )
 from qtpy.QtWidgets import (
@@ -49,6 +47,7 @@ from .comment_completion import (
     on_completer_activated,
     on_completer_key_press,
     on_completer_text_changed,
+    parse_markdown_from_web,
     setup_user_completer,
 )
 from .container import AYContainer, AYFrame
@@ -238,6 +237,8 @@ class AYCommentField(AYTextEdit):
         self._data = model
         self._bg_color = None
         self._checkbox_handler: CheckboxHandler | None = None
+        # Guard flag: when True, format_comment_on_change is a no-op.
+        self._suppress_formatting: bool = False
 
         super().__init__(*args, variant=variant, **kwargs)
         self.setAutoFormatting(QTextEdit.AutoFormattingFlag.AutoAll)
@@ -272,9 +273,17 @@ class AYCommentField(AYTextEdit):
         )
 
         # Connect text changed signal to format mentions
-        self.document().contentsChanged.connect(
-            lambda: format_comment_on_change(self)
-        )
+        self.document().contentsChanged.connect(self._on_contents_changed)
+
+    def _on_contents_changed(self) -> None:
+        """Forward contentsChanged to format_comment_on_change.
+
+        Skipped when ``_suppress_formatting`` is True so that checkbox
+        insertion code can mutate the document without triggering a
+        full re-format pass.
+        """
+        if not self._suppress_formatting:
+            format_comment_on_change(self)
 
     def get_bg_color(self, base_color: str):
         if not self._bg_color:
@@ -307,9 +316,7 @@ class AYCommentField(AYTextEdit):
             return
 
         # Check if text contains web markdown syntax
-        has_web_markdown = any(
-            pattern in md for pattern in ["\n----", "**", "_", "[", "`"]
-        )
+        has_web_markdown = bool(parse_markdown_from_web(md))
 
         if has_web_markdown:
             # Use web markdown formatting (removes syntax, applies formatting)
@@ -423,6 +430,9 @@ class AYCommentField(AYTextEdit):
     ) -> tuple[bool, int | None]:
         """Check if a click position hits a checkbox bounding rect.
 
+        Delegates to `CheckboxHandler.find_checkbox_at_click` which
+        uses stored document positions instead of scanning the full text.
+
         Args:
             click_pos: QPoint from event.pos(), viewport coords.
 
@@ -432,42 +442,12 @@ class AYCommentField(AYTextEdit):
         if not self._checkbox_handler:
             return False, None
 
-        doc = self.document()
-        text = doc.toPlainText()
-        content_offset = self.contentOffset()
-
-        offset = 0
-        while True:
-            pos = text.find("\ufffc", offset)
-            if pos == -1:
-                break
-
-            cursor = QTextCursor(doc)
-            cursor.setPosition(pos)
-            block = cursor.block()
-            block_layout = block.layout()
-
-            if block_layout:
-                rel_pos = pos - block.position()
-                line = block_layout.lineForTextPosition(rel_pos)
-                if line.isValid():
-                    x1 = line.cursorToX(rel_pos)[0]
-                    x2 = line.cursorToX(rel_pos + 1)[0]
-                    y = line.y() + block_layout.position().y()
-                    h = line.height()
-
-                    rect = QRectF(
-                        x1 + content_offset.x(),
-                        y + content_offset.y(),
-                        x2 - x1,
-                        h,
-                    )
-                    if rect.contains(QPointF(click_pos)):
-                        return True, pos + 1
-
-            offset = pos + 1
-
-        return False, None
+        result = self._checkbox_handler.find_checkbox_at_click(
+            click_pos, self.contentOffset().toPoint()
+        )
+        if result is None:
+            return False, None
+        return result
 
     def mouseDoubleClickEvent(self, event) -> None:
         """Prevent text selection when double-clicking checkboxes."""
@@ -490,15 +470,15 @@ class AYCommentField(AYTextEdit):
         # Check if clicked on a checkbox (works in both modes)
         is_cb, cb_pos = self._is_checkbox_at_cursor(event.pos())
         if is_cb and cb_pos is not None:
-            if self._checkbox_handler:
-                checkbox_idx = self._checkbox_handler.get_checkbox_at_position(
-                    cb_pos
-                )
-                if checkbox_idx is not None:
-                    self._checkbox_handler.toggle_checkbox(checkbox_idx)
-                    self.viewport().update()
-                    event.accept()
-                    return
+            assert self._checkbox_handler is not None  # implied by is_cb==True
+            checkbox_idx = self._checkbox_handler.get_checkbox_at_position(
+                cb_pos
+            )
+            if checkbox_idx is not None:
+                self._checkbox_handler.toggle_checkbox(checkbox_idx)
+                self.viewport().update()
+                event.accept()
+                return
 
         # Handle link clicks only in read-only mode (display comments)
         if self.isReadOnly():
@@ -517,7 +497,6 @@ class AYCommentField(AYTextEdit):
         """Change cursor to arrow when hovering over checkboxes, hand for links."""
         cursor = self.cursorForPosition(event.pos())
         char_format = cursor.charFormat()
-        # print(char_format.objectType())
 
         # Show arrow cursor for checkboxes (in any mode)
         if char_format.objectType() == CHECKBOX_FORMAT_TYPE:
@@ -1044,8 +1023,6 @@ if __name__ == "__main__":
             layout_margin=16,
         )
 
-        w.addStretch()
-
         w.add_widget(
             AYComment(
                 data=CommentModel(
@@ -1104,7 +1081,20 @@ if __name__ == "__main__":
         )
         w.add_widget(checklist_comment)
 
-        w.add_widget(AYTextBox(num_lines=3, variant=AYTextBox.Variants.High))
+        tb = AYTextBox(num_lines=10, variant=AYTextBox.Variants.High)
+        w.add_widget(tb)
+        tb.signals.comment_submitted.connect(
+            lambda *args: print(
+                f"Comment submitted: {'=' * (80 - len('Comment submitted: '))}\n",
+                f"{args[0]}",
+                f"{'-' * 80}\n",
+                f"   markdown: {args[0]!r}\n",
+                f"   category: {args[1]!r}\n",
+                f"attachments: {args[2]}\n",
+                f"{'-' * 80}\n",
+            )
+        )
+
         return w
 
     test(build, style=Style.AyonStyleOverCSS)

--- a/client/ayon_ui_qt/components/comment.py
+++ b/client/ayon_ui_qt/components/comment.py
@@ -42,12 +42,11 @@ from .buttons import AYButton
 from .checkbox_handler import CHECKBOX_FORMAT_TYPE, CheckboxHandler
 from .combo_box import ALL_STATUSES
 from .comment_completion import (
-    apply_web_markdown_formatting,
+    apply_code_block_backgrounds,
     format_comment_on_change,
     on_completer_activated,
     on_completer_key_press,
     on_completer_text_changed,
-    parse_markdown_from_web,
     setup_user_completer,
 )
 from .container import AYContainer, AYFrame
@@ -243,6 +242,7 @@ class AYCommentField(AYTextEdit):
         super().__init__(*args, variant=variant, **kwargs)
         self.setAutoFormatting(QTextEdit.AutoFormattingFlag.AutoAll)
         self.setSizeAdjustPolicy(QTextEdit.SizeAdjustPolicy.AdjustToContents)
+        self.document().setIndentWidth(22)
         # Enable mouse tracking on viewport to receive mouseMoveEvent
         # self.setMouseTracking(True)
         self.viewport().setMouseTracking(True)
@@ -284,6 +284,7 @@ class AYCommentField(AYTextEdit):
         """
         if not self._suppress_formatting:
             format_comment_on_change(self)
+            apply_code_block_backgrounds(self)
 
     def get_bg_color(self, base_color: str):
         if not self._bg_color:
@@ -315,15 +316,8 @@ class AYCommentField(AYTextEdit):
                 self._adjust_height_to_content()
             return
 
-        # Check if text contains web markdown syntax
-        has_web_markdown = bool(parse_markdown_from_web(md))
-
-        if has_web_markdown:
-            # Use web markdown formatting (removes syntax, applies formatting)
-            self.set_web_markdown(md)
-        else:
-            # Use standard markdown
-            self.document().setMarkdown(md, MD_DIALECT)
+        self.document().setMarkdown(md, MD_DIALECT)
+        apply_code_block_backgrounds(self)
 
         if self._read_only:
             self._adjust_height_to_content()
@@ -341,18 +335,6 @@ class AYCommentField(AYTextEdit):
         self.checklist_changed.emit()
         if self._read_only:
             self._adjust_height_to_content()
-
-    def set_web_markdown(self, md: str, styles: dict | None = None) -> None:
-        """Set markdown from web data with formatting.
-
-        Removes markdown syntax (**text** becomes text with bold formatting).
-
-        Args:
-            md: Markdown text from web (**bold**, _italic_, [link](url), `code`)
-            styles: Optional custom styles for formatting
-        """
-        apply_web_markdown_formatting(self, md, styles=styles)
-        self.setReadOnly(self._read_only)
 
     def as_markdown(self) -> str:
         """Get the content as GitHub-flavored markdown.
@@ -1035,7 +1017,16 @@ if __name__ == "__main__":
                 data=CommentModel(
                     user_src=str(av1),
                     user_full_name="Bob Morane",
-                    comment="This is great !",
+                    comment=(
+                        "Text Styling\n"
+                        "------------\n"
+                        "regular, **bold**, *italic*, ***bold italic*** and `some code` text.\n\n"
+                        "```\n"
+                        "# A code fragment\n"
+                        "print('Hello World')\n"
+                        "```\n\n"
+                        "Is it all working ?\n"
+                    ),
                 )
             )
         )

--- a/client/ayon_ui_qt/components/comment.py
+++ b/client/ayon_ui_qt/components/comment.py
@@ -712,6 +712,7 @@ class AYComment(AYContainer):
         self._user_list: list[User] = user_list or []
         self._bg_color = None
         self._image_widgets = {}
+        self._attachments_built = False
 
         super().__init__(
             *args,
@@ -728,12 +729,20 @@ class AYComment(AYContainer):
 
         # configure
         if self._data:
-            self.text_field.set_markdown(self._data.comment)
-            self.date.setText(self._data.short_date)
-            self.set_comment_category()
-            self._build_image_attachments()
+            self.update_comment()
 
         self.text_field.checklist_changed.connect(self._on_checklist_changed)
+
+    def update_comment(self, data: CommentModel | None = None):
+        prev_data = self._data
+        if data:
+            self._data = data
+        self.text_field.set_markdown(self._data.comment)
+        self.date.setText(self._data.short_date)
+        self.set_comment_category()
+        if not self._attachments_built or prev_data.files != self._data.files:
+            self.images_container.clear()
+            self._build_image_attachments()
 
     def _build_top_bar(self):
         self.user_icon = AYUserImage(
@@ -892,16 +901,11 @@ class AYComment(AYContainer):
                 frame=file_model.frame,
             )
 
-            # # Set fixed width to prevent expanding
-            # image_widget.setFixedWidth(max_image_width)
-            # # Set maximum height to maintain aspect ratio
-            # image_widget.setMaximumHeight(800)
-
             self.images_container.add_widget(image_widget)
             self._image_widgets[file_model.id] = image_widget
 
-        # # Add stretch to push images to the left
-        # self.images_container.addStretch()
+        # mark as built to avoid rebuilding on every update
+        self._attachments_built = True
 
     def _edit_comment(self):
         """Make the field editable, hide the edit/del buttons and show
@@ -1021,10 +1025,14 @@ if __name__ == "__main__":
                         "Text Styling\n"
                         "------------\n"
                         "regular, **bold**, *italic*, ***bold italic*** and `some code` text.\n\n"
+                        "[A link](https://www.google.com)\n\n"
                         "```\n"
                         "# A code fragment\n"
                         "print('Hello World')\n"
                         "```\n\n"
+                        "1. First item\n"
+                        "2. Second item\n"
+                        "3. Third item\n\n"
                         "Is it all working ?\n"
                     ),
                 )

--- a/client/ayon_ui_qt/components/comment.py
+++ b/client/ayon_ui_qt/components/comment.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from qtpy.QtCore import QEvent, QPoint, QRect, QSize, Qt, Signal
+from qtpy.QtCore import (
+    QEvent,
+    QPoint,
+    QPointF,
+    QRect,
+    QRectF,
+    Qt,
+    Signal,
+)
 from qtpy.QtGui import (
     QColor,
     QEnterEvent,
@@ -388,6 +396,21 @@ class AYCommentField(AYTextEdit):
         if self._read_only:
             self._adjust_height_to_content()
 
+    def contentOffset(self) -> QPointF:
+        """Compute content offset (QPlainTextEdit compatibility).
+
+        Returns the offset from viewport coordinates to document coordinates.
+        This method provides compatibility with QPlainTextEdit for checkbox
+        hit-testing in _is_checkbox_at_cursor.
+
+        Returns:
+            QPointF offset where viewport origin corresponds to document coords.
+        """
+        return QPointF(
+            -self.horizontalScrollBar().value(),
+            -self.verticalScrollBar().value(),
+        )
+
     def keyPressEvent(self, event) -> None:
         """Handle key press events for completer."""
         if on_completer_key_press(self, event):
@@ -395,25 +418,55 @@ class AYCommentField(AYTextEdit):
             return
         super().keyPressEvent(event)
 
-    def _is_checkbox_at_cursor(self, cursor) -> tuple[bool, int | None]:
-        """Check if a checkbox is at or adjacent to the cursor position.
+    def _is_checkbox_at_cursor(
+        self, click_pos: QPoint
+    ) -> tuple[bool, int | None]:
+        """Check if a click position hits a checkbox bounding rect.
 
         Args:
-            cursor: QTextCursor from cursorForPosition.
+            click_pos: QPoint from event.pos(), viewport coords.
 
         Returns:
-            Tuple of (is_checkbox, document_position_of_checkbox).
+            Tuple of (is_checkbox, document_position_for_lookup).
         """
+        if not self._checkbox_handler:
+            return False, None
+
         doc = self.document()
-        pos = cursor.position()
-        for check_pos in (pos, pos - 1, pos + 1):
-            if not (0 <= check_pos < doc.characterCount()):
-                continue
-            tmp = QTextCursor(doc)
-            tmp.setPosition(check_pos)
-            tmp.setPosition(check_pos - 1, QTextCursor.MoveMode.KeepAnchor)
-            if tmp.charFormat().objectType() == CHECKBOX_FORMAT_TYPE:
-                return True, check_pos
+        text = doc.toPlainText()
+        content_offset = self.contentOffset()
+
+        offset = 0
+        while True:
+            pos = text.find("\ufffc", offset)
+            if pos == -1:
+                break
+
+            cursor = QTextCursor(doc)
+            cursor.setPosition(pos)
+            block = cursor.block()
+            block_layout = block.layout()
+
+            if block_layout:
+                rel_pos = pos - block.position()
+                line = block_layout.lineForTextPosition(rel_pos)
+                if line.isValid():
+                    x1 = line.cursorToX(rel_pos)[0]
+                    x2 = line.cursorToX(rel_pos + 1)[0]
+                    y = line.y() + block_layout.position().y()
+                    h = line.height()
+
+                    rect = QRectF(
+                        x1 + content_offset.x(),
+                        y + content_offset.y(),
+                        x2 - x1,
+                        h,
+                    )
+                    if rect.contains(QPointF(click_pos)):
+                        return True, pos + 1
+
+            offset = pos + 1
+
         return False, None
 
     def mousePressEvent(self, event) -> None:
@@ -427,14 +480,11 @@ class AYCommentField(AYTextEdit):
         char_format = cursor.charFormat()
 
         # Check if clicked on a checkbox (works in both modes)
-        is_cb, _ = self._is_checkbox_at_cursor(cursor)
-        # if char_format.objectType() == CHECKBOX_FORMAT_TYPE:
-        if is_cb:
+        is_cb, cb_pos = self._is_checkbox_at_cursor(event.pos())
+        if is_cb and cb_pos is not None:
             if self._checkbox_handler:
-                # Get cursor position to find which checkbox
-                pos = cursor.position()
                 checkbox_idx = self._checkbox_handler.get_checkbox_at_position(
-                    pos
+                    cb_pos
                 )
                 if checkbox_idx is not None:
                     self._checkbox_handler.toggle_checkbox(checkbox_idx)
@@ -958,7 +1008,9 @@ class AYComment(AYContainer):
         if isinstance(image_attachment, AYImageAttachment):
             if not image_attachment._thumb_path:
                 ic = ImageCache.get_instance()
-                image_attachment._thumb_path = ic.get_path(f"act_thumb_{file_id}")
+                image_attachment._thumb_path = ic.get_path(
+                    f"act_thumb_{file_id}"
+                )
             if not image_attachment._image_path:
                 ic = ImageCache.get_instance()
                 image_attachment._image_path = ic.get_path(f"act_{file_id}")

--- a/client/ayon_ui_qt/components/comment_completion.py
+++ b/client/ayon_ui_qt/components/comment_completion.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import re
+import logging
 
 from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import (
-    QFont,
+    QColor,
     QPainter,
     QStandardItem,
     QStandardItemModel,
+    QSyntaxHighlighter,
+    QTextBlockFormat,
     QTextCharFormat,
     QTextCursor,
 )
@@ -22,6 +25,13 @@ from qtpy.QtWidgets import (
 from .. import get_ayon_style
 from ..data_models import User
 from .user_image import AYUserImage
+
+# Background colour used for both character-level (inline code) and
+# block-level (fenced code block) highlighting.  Defined once here so
+# that both the highlighter and ``apply_code_block_backgrounds()`` always
+# use the same value.
+CODE_BG: QColor = QColor("#1e1e1e")
+CODE_FG: QColor = QColor("#eeeeee")
 
 
 class UserCompleterDelegate(QStyledItemDelegate):
@@ -297,401 +307,298 @@ def on_completer_key_press(
     return False
 
 
-def parse_markdown_from_web(text: str) -> list[dict]:
-    """Parse web markdown syntax and return format information.
+class MentionHighlighter(QSyntaxHighlighter):
+    """Syntax highlighter for @mentions, raw URLs, and code spans.
 
-    Identifies H1 (text\n----), **bold**, _italic_, [link](url),
-    and `code` patterns.
+    Operates on block-local plain text so positions are always correct
+    regardless of any rich-text formatting already present in the document
+    (bold, italic, headings, code spans, etc.).
 
-    Args:
-        text: Markdown text containing web syntax
+    Patterns highlighted:
 
-    Returns:
-        List of dicts with keys: 'type', 'start', 'end', 'content', 'url'
-    """
-    formats = []
-
-    # Pattern for H1 (text followed by newline and dashes)
-    for match in re.finditer(r"^(.+?)\n-{2,}$", text, re.MULTILINE):
-        formats.append(
-            {
-                "type": "h1",
-                "start": match.start(),
-                "end": match.end(),
-                "content": match.group(1),
-            }
-        )
-
-    # Pattern for **bold**
-    for match in re.finditer(r"\*\*(.+?)\*\*", text):
-        formats.append(
-            {
-                "type": "bold",
-                "start": match.start(),
-                "end": match.end(),
-                "content": match.group(1),
-            }
-        )
-
-    # Pattern for _italic_
-    for match in re.finditer(r"_(.+?)_", text):
-        formats.append(
-            {
-                "type": "italic",
-                "start": match.start(),
-                "end": match.end(),
-                "content": match.group(1),
-            }
-        )
-
-    # Pattern for [link](url)
-    for match in re.finditer(r"\[(.+?)\]\((.+?)\)", text):
-        formats.append(
-            {
-                "type": "link",
-                "start": match.start(),
-                "end": match.end(),
-                "content": match.group(1),
-                "url": match.group(2),
-            }
-        )
-
-    # Pattern for `code`
-    for match in re.finditer(r"`(.+?)`", text):
-        formats.append(
-            {
-                "type": "code",
-                "start": match.start(),
-                "end": match.end(),
-                "content": match.group(1),
-            }
-        )
-
-    return formats
-
-
-def apply_web_markdown_formatting(
-    text_edit: QTextEdit,
-    text: str,
-    styles: dict | None = None,
-) -> None:
-    """Apply web markdown formatting to text, removing syntax.
-
-    Removes markdown syntax while preserving formatting
-    (**bold** becomes bold text, _italic_ becomes italic text, etc).
+    - Fenced code blocks (```\\`\\`\\` ... \\`\\`\\```) spanning multiple lines —
+      black background, white monospace text.  Block state ``1`` tracks
+      whether the current block is inside a fence.
+    - Qt-rendered code blocks (from ``setMarkdown()``) — detected via
+      ``nonBreakableLines`` on the block format.
+    - Qt-rendered inline code spans (from ``setMarkdown()``) — detected via
+      ``fontFixedPitch`` on individual text fragments.
+    - Inline code spans (`` \\`code\\` ``) in raw (un-rendered) text — same
+      style, detected by backtick regex.
+    - ``@@@word`` — task mention
+    - ``@@word``  — version mention
+    - ``@word``   — user mention (only the first word if the full name is not
+      in the known user list; both words when it is)
+    - ``https?://…`` — raw URL
 
     Args:
-        text_edit: QTextEdit widget to apply formatting to
-        text: Markdown text from web
-        styles: Optional custom styles dict with keys: "bold", "italic", "link", "code"
+        document: The QTextDocument to attach to.
+        user_list: Live list of :class:`~..data_models.User` objects used to
+            decide whether a two-word mention should be highlighted in full.
     """
-    pal = get_ayon_style().model.base_palette
 
-    # Parse markdown to find all format positions
-    formats = parse_markdown_from_web(text)
+    # Compiled patterns — order matters: longer prefixes first so that
+    # ``@@@`` is matched before ``@@`` and ``@@`` before ``@``.
+    _P_TASK = re.compile(r"@@@\w+( \w+)?")
+    _P_VERSION = re.compile(r"@@(?!@)\w+( \w+)?")
+    _P_USER = re.compile(r"@(?!@)\w+( \w+)?")
+    _P_RAW_LINK = re.compile(r"https?://\S+")
+    # Inline code: single backtick pair on the same line.
+    _P_CODE_INLINE = re.compile(r"`[^`\n]+`")
 
-    # Sort by start position (reverse order for proper offset calculation)
-    formats.sort(key=lambda x: x["start"], reverse=True)
+    def __init__(self, document, user_list: list) -> None:
+        super().__init__(document)
+        self._user_list = user_list
+        pal = get_ayon_style().model.base_palette
+        self._mention_fmt = QTextCharFormat()
+        self._mention_fmt.setForeground(pal.link())
+        self._code_fmt = QTextCharFormat()
+        self._code_fmt.setFontFixedPitch(True)
+        self._code_fmt.setFontFamilies(
+            ["Courier New", "Menlo", "Monaco", "monospace"]
+        )
+        self._code_fmt.setBackground(CODE_BG)
+        self._code_fmt.setForeground(CODE_FG)
 
-    # Build plain text by removing syntax and track position mappings
-    plain_text = text
-    position_map = {}  # Maps original positions to new positions
+    def update_user_list(self, user_list: list) -> None:
+        """Replace the user list and trigger a full rehighlight.
 
-    for fmt in formats:
-        start = fmt["start"]
-        end = fmt["end"]
-        content = fmt["content"]
-        fmt_type = fmt["type"]
+        Args:
+            user_list: Updated list of User objects.
+        """
+        self._user_list = user_list
+        self.rehighlight()
 
-        # Calculate what to remove based on format type
-        if fmt_type == "h1":
-            plain_text = plain_text[:start] + content + plain_text[end:]
-            position_map[fmt_type] = (start, start + len(content))
-        elif fmt_type == "bold":
-            plain_text = plain_text[:start] + content + plain_text[end:]
-            position_map[fmt_type] = (start, start + len(content))
-        elif fmt_type == "italic":
-            plain_text = plain_text[:start] + content + plain_text[end:]
-            position_map[fmt_type] = (start, start + len(content))
-        elif fmt_type == "link":
-            link_text = fmt["content"]
-            plain_text = plain_text[:start] + link_text + plain_text[end:]
-            position_map[fmt_type] = (start, start + len(link_text))
-        elif fmt_type == "code":
-            plain_text = plain_text[:start] + content + plain_text[end:]
-            position_map[fmt_type] = (start, start + len(content))
+    def highlightBlock(self, text: str) -> None:
+        """Apply code, mention, and URL highlighting to a single block.
 
-    # Set plain text
-    text_edit.setPlainText(plain_text)
+        Two detection strategies are combined so that code is styled in both
+        *edit mode* (raw markdown typed by the user) and *display mode*
+        (rich text rendered via ``document().setMarkdown()``):
 
-    # Block signals and start edit block for performance
-    text_edit.document().blockSignals(True)
-    cursor = text_edit.textCursor()
-    cursor.beginEditBlock()
+        **Edit mode — raw fence markers:**
+        Uses block state ``1`` to track multi-line fenced code blocks. A line
+        starting with *```* opens or closes a fence; every line inside the
+        fence is styled with :attr:`_code_fmt`.  A line that both opens and
+        closes a fence on the same line (e.g. ``\\`\\`\\`code\\`\\`\\```) is
+        treated as a single-line code block with no state change.
 
-    # Re-parse to get all formats with their new positions
-    formats = parse_markdown_from_web(text)
-    formats.sort(key=lambda x: x["start"], reverse=True)
+        **Display mode — Qt-rendered char formats:**
+        After ``setMarkdown()`` Qt strips the fence markers and stores rich
+        text character formats.  Fenced code blocks have
+        ``nonBreakableLines=True`` set on the block format (``fontFixedPitch``
+        stays ``False`` on the block-level char format).  Inline code spans
+        set ``fontFixedPitch=True`` on individual text *fragments* within a
+        paragraph.  Both are detected here and styled with :attr:`_code_fmt`.
 
-    # Build mapping of original to plain text positions
-    plain_text = text
-    offset_map = {}
-    current_offset = 0
+        Inline code spans from raw backtick syntax (`` \\`code\\` ``) are also
+        detected via :attr:`_P_CODE_INLINE` for live-typed backtick spans.
 
-    for fmt in formats:
-        start = fmt["start"]
-        end = fmt["end"]
-        content = fmt["content"]
-        fmt_type = fmt["type"]
+        Code formatting is applied *after* mention/URL patterns so that it
+        takes precedence over any mention highlight inside a code span.
 
-        # Track the offset and new position
-        if fmt_type == "h1":
-            # H1 syntax: text\n---- the match.end() already includes the dashes
-            # So the syntax_len is the difference between match end and content
-            syntax_len = end - start - len(content)
-            offset_map[start] = (
-                start - current_offset,
-                start - current_offset + len(content),
-            )
-            current_offset += syntax_len
-        elif fmt_type == "bold":
-            syntax_len = len(f"**{content}**") - len(content)
-            offset_map[start] = (
-                start - current_offset,
-                start - current_offset + len(content),
-            )
-            current_offset += syntax_len
-        elif fmt_type == "italic":
-            syntax_len = len(f"_{content}_") - len(content)
-            offset_map[start] = (
-                start - current_offset,
-                start - current_offset + len(content),
-            )
-            current_offset += syntax_len
-        elif fmt_type == "link":
-            syntax_len = len(fmt["content"] + fmt.get("url", "")) + 4
-            offset_map[start] = (
-                start - current_offset,
-                start - current_offset + len(content),
-            )
-            current_offset += syntax_len
-        elif fmt_type == "code":
-            syntax_len = len(f"`{content}`") - len(content)
-            offset_map[start] = (
-                start - current_offset,
-                start - current_offset + len(content),
-            )
-            current_offset += syntax_len
+        Called automatically by Qt whenever the block changes.
 
-    # Now apply formatting in correct order (forward iteration)
-    formats_sorted = parse_markdown_from_web(text)
-    formats_sorted.sort(key=lambda x: x["start"])
+        Args:
+            text: Plain text content of the current block.
+        """
+        block = self.currentBlock()
+        in_fence = self.previousBlockState() == 1
 
-    # Create a list to accumulate offset changes
-    cumulative_offset = 0
-    format_list = []
+        # ── Edit mode: raw fence markers ─────────────────────────────────
+        if in_fence:
+            # The entire line belongs to the open fenced block.
+            self.setFormat(0, len(text), self._code_fmt)
+            # A line starting with ``` closes the fence.
+            if text.startswith("```"):
+                self.setCurrentBlockState(0)
+            else:
+                self.setCurrentBlockState(1)
+            return
 
-    for fmt in formats_sorted:
-        start = fmt["start"] - cumulative_offset
-        content = fmt["content"]
-        fmt_type = fmt["type"]
-        url = fmt.get("url", "")
+        if text.startswith("```"):
+            self.setFormat(0, len(text), self._code_fmt)
+            rest = text[3:]
+            # Closing ``` on the same line → single-line block, no state.
+            if "```" in rest:
+                self.setCurrentBlockState(0)
+            else:
+                self.setCurrentBlockState(1)
+            return
 
-        if fmt_type == "h1":
-            # H1: text\n---- becomes just text
-            end = start + len(content)
-            # The cumulative offset is the difference between original end and new end
-            original_syntax_len = (
-                fmt["end"] - fmt["start"] - len(fmt["content"])
-            )
-            cumulative_offset += original_syntax_len
-        elif fmt_type == "bold":
-            end = start + len(content)
-            cumulative_offset += len(f"**{content}**") - len(content)
-        elif fmt_type == "italic":
-            end = start + len(content)
-            cumulative_offset += len(f"_{content}_") - len(content)
-        elif fmt_type == "link":
-            end = start + len(content)
-            cumulative_offset += len(fmt["content"] + fmt.get("url", "")) + 4
-        elif fmt_type == "code":
-            end = start + len(content)
-            cumulative_offset += len(f"`{content}`") - len(content)
+        self.setCurrentBlockState(0)
 
-        format_list.append((fmt_type, start, end, url))
+        # ── Display mode: Qt-rendered whole-block code ───────────────────
+        # After setMarkdown(), Qt marks fenced code block lines with
+        # nonBreakableLines=True on the block format.  The char format
+        # carries fontFamilies=['monospace'] but fontFixedPitch stays False.
+        # Style the whole line and skip mention/URL patterns — they don't
+        # belong inside code.
+        if block.blockFormat().nonBreakableLines():
+            self.setFormat(0, len(text), self._code_fmt)
+            return
 
-    # Apply formats from the accumulated list
-    for fmt_type, start, end, url in format_list:
-        char_fmt = QTextCharFormat()
+        # ── Mentions and URLs (applied before inline code) ───────────────
+        users = {u.full_name for u in self._user_list}
 
-        if fmt_type == "h1":
-            # Get base font size and apply H1 styling (1.5x larger, bold)
-            # Try multiple sources for font size
-            base_size = text_edit.font().pointSize()
-            if base_size <= 0:
-                base_size = text_edit.document().defaultFont().pointSize()
-            if base_size <= 0:
-                base_size = text_edit.fontInfo().pointSize()
-            if base_size <= 0:
-                base_size = 12  # Fallback
+        # Task mentions (@@@)
+        for m in self._P_TASK.finditer(text):
+            self.setFormat(m.start(), m.end() - m.start(), self._mention_fmt)
 
-            char_fmt.setFontPointSize(int(base_size * 1.5))
-            char_fmt.setFontWeight(QFont.Weight.Bold)
-            if styles and "h1" in styles and "color" in styles["h1"]:
-                char_fmt.setForeground(styles["h1"]["color"])
-        elif fmt_type == "bold":
-            char_fmt.setFontWeight(QFont.Weight.Bold)
-            if styles and "bold" in styles and "color" in styles["bold"]:
-                char_fmt.setForeground(styles["bold"]["color"])
-        elif fmt_type == "italic":
-            char_fmt.setFontItalic(True)
-            if styles and "italic" in styles and "color" in styles["italic"]:
-                char_fmt.setForeground(styles["italic"]["color"])
-        elif fmt_type == "link":
-            char_fmt.setForeground(pal.link())
-            char_fmt.setFontUnderline(True)
-            # Set anchor href for link
-            char_fmt.setAnchor(True)
-            char_fmt.setAnchorHref(url)
-            if styles and "link" in styles and "color" in styles["link"]:
-                char_fmt.setForeground(styles["link"]["color"])
-        elif fmt_type == "code":
-            code_font = QFont()
-            code_font.setFixedPitch(True)
-            char_fmt.setFont(code_font)
-            char_fmt.setForeground(pal.light())
-            if styles and "code" in styles and "color" in styles["code"]:
-                char_fmt.setForeground(styles["code"]["color"])
+        # Version mentions (@@)
+        for m in self._P_VERSION.finditer(text):
+            self.setFormat(m.start(), m.end() - m.start(), self._mention_fmt)
 
-        # Apply format to the range
-        cursor.setPosition(start)
-        cursor.setPosition(end, QTextCursor.MoveMode.KeepAnchor)
-        cursor.setCharFormat(char_fmt)
+        # User mentions (@) — highlight only the first word unless the full
+        # two-word name is in the known user list.
+        for m in self._P_USER.finditer(text):
+            full_match = m.group(0)
+            mention_name = full_match[1:]  # strip leading @
+            if mention_name in users:
+                length = len(full_match)
+            else:
+                # Highlight only up to the first word (no trailing space+word)
+                length = len(full_match.split()[0])
+            self.setFormat(m.start(), length, self._mention_fmt)
 
-    # End edit block and unblock signals
-    cursor.endEditBlock()
-    text_edit.document().blockSignals(False)
+        # Raw URLs
+        for m in self._P_RAW_LINK.finditer(text):
+            self.setFormat(m.start(), m.end() - m.start(), self._mention_fmt)
 
-    # Clear selection and place cursor at end
-    cursor.clearSelection()
-    cursor.movePosition(QTextCursor.MoveOperation.End)
-    text_edit.setTextCursor(cursor)
+        # ── Inline code (applied last, overrides mention formatting) ─────
+
+        # Raw backtick syntax `code` — detected in plain text for live
+        # editing where backtick characters are still present:
+        for m in self._P_CODE_INLINE.finditer(text):
+            self.setFormat(m.start(), m.end() - m.start(), self._code_fmt)
+
+        # Qt-rendered inline code spans — after setMarkdown() the backticks
+        # are consumed and individual fragments carry fontFixedPitch=True:
+        it = block.begin()
+        while not it.atEnd():
+            fragment = it.fragment()
+            if fragment.isValid() and fragment.charFormat().fontFixedPitch():
+                frag_start = fragment.position() - block.position()
+                self.setFormat(frag_start, fragment.length(), self._code_fmt)
+            it += 1
 
 
 def format_comment_on_change(text_edit: QTextEdit) -> None:
-    """Format QTextDocument to highlight mentions starting with @.
+    """Ensure a :class:`MentionHighlighter` is installed on *text_edit*.
 
-    Any word starting with @ will be formatted in red.
-    Preserves checkbox formatting (CHECKBOX_FORMAT_TYPE).
+    Idempotent: safe to call on every ``contentsChanged`` signal.  The
+    highlighter is created once and attached to the document.  Subsequent
+    calls only call :meth:`MentionHighlighter.update_user_list` when the
+    ``_user_list`` reference on *text_edit* has been replaced (e.g. after a
+    server refresh), which avoids triggering an unnecessary ``rehighlight``
+    — and the infinite-recursion that would follow — on every keystroke.
+
+    Args:
+        text_edit: The QTextEdit whose document should have mention
+            highlighting applied.
     """
-    # Import here to avoid circular dependency
-    from .checkbox_handler import CHECKBOX_FORMAT_TYPE
+    highlighter: MentionHighlighter | None = getattr(
+        text_edit, "_mention_highlighter", None
+    )
+    user_list = getattr(text_edit, "_user_list", [])
 
-    text_edit.document().blockSignals(True)
+    if highlighter is None:
+        highlighter = MentionHighlighter(text_edit.document(), user_list)
+        text_edit._mention_highlighter = highlighter  # type: ignore[attr-defined]
+    elif highlighter._user_list is not user_list:
+        # The list object was replaced (e.g. after a user-list refresh).
+        # update_user_list() calls rehighlight() which is safe here because
+        # this branch is only reached when _suppress_formatting is False and
+        # the list identity has changed — not on every keystroke.
+        highlighter.update_user_list(user_list)
 
-    pal = get_ayon_style().model.base_palette
-    document = text_edit.document()
-    cursor = text_edit.textCursor()
 
-    # Create minimal mention/link formats — only mention-specific properties
-    # are set so that mergeCharFormat preserves user styles (bold, italic, etc.)
-    user_format = QTextCharFormat()
-    user_format.setForeground(pal.link())
-    url_format = QTextCharFormat()
-    url_format.setForeground(pal.link())
-    url_format.setFontUnderline(True)
+def apply_code_block_backgrounds(text_edit: QTextEdit) -> None:
+    """Apply a full-width background colour to every fenced code block.
 
-    # Track link colour and default text brush for selective clearing
-    link_color = pal.link().color()
-    default_text_brush = pal.text()
+    ``QSyntaxHighlighter.setFormat()`` only paints behind individual
+    text characters, so the end of a short line keeps the regular widget
+    background.  Setting ``QTextBlockFormat.background`` instead causes
+    Qt's own layout engine to paint the background across the *entire*
+    width of the block before any characters are drawn.
 
-    # Get all text from document
-    md = document.toMarkdown()
+    This function is intentionally separate from
+    :class:`MentionHighlighter` because Qt's documentation forbids
+    modifying the document from inside ``highlightBlock()``.
 
-    users = [u.full_name for u in text_edit._user_list]
+    Two detection strategies are combined so that code blocks are
+    recognised in both scenarios:
 
-    # Find all words starting with @, @@, or @@@
-    p_user = r"(?P<user>@(?!@)\w+( \w+)?)"
-    p_version = r"(?P<version>@@(?!@)\w+( \w+)?)"
-    p_task = r"(?P<task>@@@\w+( \w+)?)"
-    p_link = r"(?P<link>\[[\w\s]+\]\(.+\))"
-    p_raw_link = r"(?P<raw_link>https?://)"
-    p_all = f"{p_user}|{p_version}|{p_task}|{p_link}|{p_raw_link}"
-    matches = list(re.finditer(p_all, md))
+    - **Display mode** (after ``document().setMarkdown()``): Qt marks
+      fenced code block lines with ``nonBreakableLines=True`` on the
+      block format.
+    - **Edit mode** (raw typing): Lines inside a ``\\`\\`\\`…\\`\\`\\```` fence
+      are detected by tracking an open-fence flag while iterating from
+      the first block of the document.
 
-    # Clear only mention/link-related formatting so that user-applied styles
-    # (bold, italic, heading, code, background, font family, etc.) are
-    # preserved across keystrokes.
-    text = document.toPlainText()
-    for i in range(len(text)):
-        cursor.setPosition(i)
-        cursor.setPosition(i + 1, QTextCursor.MoveMode.KeepAnchor)
-        char_fmt = cursor.charFormat()
-        # Skip checkbox objects — preserve their formatting entirely
-        if char_fmt.objectType() == CHECKBOX_FORMAT_TYPE:
-            continue
-        # Only reset properties that were set by mention/link formatting
-        has_mention_fmt = (
-            char_fmt.isAnchor()
-            or char_fmt.fontUnderline()
-            or char_fmt.foreground().color() == link_color
-        )
-        if has_mention_fmt:
-            clear_fmt = QTextCharFormat()
-            clear_fmt.setAnchor(False)
-            clear_fmt.setAnchorHref("")
-            clear_fmt.setFontUnderline(False)
-            if char_fmt.foreground().color() == link_color:
-                clear_fmt.setForeground(default_text_brush)
-            cursor.mergeCharFormat(clear_fmt)
+    The function is guarded by the ``_suppress_formatting`` attribute on
+    *text_edit* to prevent infinite recursion: writing block formats
+    emits ``contentsChanged``, which would otherwise re-enter this
+    function.
 
-    # We parsed the markdown but the cursor if using the plain text, so we
-    # need to keep track of the number of extra markdown characters to keep
-    # things aligned.
-    xtra = 0
-    for match in matches:
-        for key, val in match.groupdict().items():
-            if val is None:
-                continue
-            if key == "user":
-                cursor.setPosition(match.start())
-                if val[1:] in users:
-                    cursor.setPosition(
-                        match.end(), QTextCursor.MoveMode.KeepAnchor
-                    )
-                else:
-                    cursor.setPosition(
-                        match.end() - len(val.split()[-1]),
-                        QTextCursor.MoveMode.KeepAnchor,
-                    )
+    Args:
+        text_edit: The QTextEdit whose document should have fenced code
+            block backgrounds applied.
+    """
+    if getattr(text_edit, "_suppress_formatting", False):
+        return
 
-                cursor.mergeCharFormat(user_format)
-            elif key == "version":
-                cursor.setPosition(match.start())
-                cursor.setPosition(
-                    match.end(), QTextCursor.MoveMode.KeepAnchor
-                )
-                cursor.mergeCharFormat(user_format)
-            elif key == "task":
-                cursor.setPosition(match.start())
-                cursor.setPosition(
-                    match.end(), QTextCursor.MoveMode.KeepAnchor
-                )
-                cursor.mergeCharFormat(user_format)
-            if key == "raw_link":
-                cursor.setPosition(match.start())
-                cursor.setPosition(
-                    match.end(), QTextCursor.MoveMode.KeepAnchor
-                )
-                cursor.mergeCharFormat(user_format)
-            elif key == "link":
-                p0 = match.start() - xtra
-                cursor.setPosition(p0)
-                link_name = re.search(r"\[(.+)\]", val).group(1)
-                p1 = (match.start() - xtra) + len(link_name)
-                cursor.setPosition(p1, QTextCursor.MoveMode.KeepAnchor)
-                xtra += len(val) - len(link_name) + 1
-                cursor.mergeCharFormat(url_format)
+    doc = text_edit.document()
+    setattr(text_edit, "_suppress_formatting", True)
 
-    # Restore original cursor position
-    text_edit.document().blockSignals(False)
+    cursor = QTextCursor(doc)
+    cursor.beginEditBlock()
+
+    try:
+        in_fence = False
+        block = doc.begin()
+        while block.isValid():
+            text = block.text()
+            is_code = False
+
+            # Display mode: Qt-rendered fenced code block.
+            if block.blockFormat().nonBreakableLines():
+                is_code = True
+            else:
+                # Edit mode: raw ``` fence markers.
+                if in_fence:
+                    is_code = True
+                    if text.startswith("```"):
+                        in_fence = False  # closing fence line — still code
+                elif text.startswith("```"):
+                    is_code = True
+                    rest = text[3:]
+                    if "```" not in rest:
+                        in_fence = True  # opening fence
+                    # else: single-line ```…``` — is_code=True, no state change
+
+            bg_brush = block.blockFormat().background()
+            has_code_bg = (
+                bg_brush.style() != Qt.BrushStyle.NoBrush
+                and bg_brush.color().rgb() == CODE_BG.rgb()
+            )
+
+            if is_code and not has_code_bg:
+                cursor.setPosition(block.position())
+                new_fmt = QTextBlockFormat()
+                new_fmt.setBackground(CODE_BG)
+                cursor.mergeBlockFormat(new_fmt)
+            elif not is_code and has_code_bg:
+                # Remove the previously applied code background.
+                cursor.setPosition(block.position())
+                restored = QTextBlockFormat(block.blockFormat())
+                restored.clearBackground()
+                cursor.setBlockFormat(restored)
+
+            block = block.next()
+    except Exception as e:
+        logging.info(f"Error in apply_code_block_backgrounds: {e}")
+    finally:
+        # Ensure we always end the edit block and reset the flag
+        cursor.endEditBlock()
+        setattr(text_edit, "_suppress_formatting", False)

--- a/client/ayon_ui_qt/components/comment_completion.py
+++ b/client/ayon_ui_qt/components/comment_completion.py
@@ -313,49 +313,59 @@ def parse_markdown_from_web(text: str) -> list[dict]:
 
     # Pattern for H1 (text followed by newline and dashes)
     for match in re.finditer(r"^(.+?)\n-{2,}$", text, re.MULTILINE):
-        formats.append({
-            "type": "h1",
-            "start": match.start(),
-            "end": match.end(),
-            "content": match.group(1),
-        })
+        formats.append(
+            {
+                "type": "h1",
+                "start": match.start(),
+                "end": match.end(),
+                "content": match.group(1),
+            }
+        )
 
     # Pattern for **bold**
     for match in re.finditer(r"\*\*(.+?)\*\*", text):
-        formats.append({
-            "type": "bold",
-            "start": match.start(),
-            "end": match.end(),
-            "content": match.group(1),
-        })
+        formats.append(
+            {
+                "type": "bold",
+                "start": match.start(),
+                "end": match.end(),
+                "content": match.group(1),
+            }
+        )
 
     # Pattern for _italic_
-    for match in re.finditer(r'_(.+?)_', text):
-        formats.append({
-            "type": "italic",
-            "start": match.start(),
-            "end": match.end(),
-            "content": match.group(1),
-        })
+    for match in re.finditer(r"_(.+?)_", text):
+        formats.append(
+            {
+                "type": "italic",
+                "start": match.start(),
+                "end": match.end(),
+                "content": match.group(1),
+            }
+        )
 
     # Pattern for [link](url)
     for match in re.finditer(r"\[(.+?)\]\((.+?)\)", text):
-        formats.append({
-            "type": "link",
-            "start": match.start(),
-            "end": match.end(),
-            "content": match.group(1),
-            "url": match.group(2),
-        })
+        formats.append(
+            {
+                "type": "link",
+                "start": match.start(),
+                "end": match.end(),
+                "content": match.group(1),
+                "url": match.group(2),
+            }
+        )
 
     # Pattern for `code`
     for match in re.finditer(r"`(.+?)`", text):
-        formats.append({
-            "type": "code",
-            "start": match.start(),
-            "end": match.end(),
-            "content": match.group(1),
-        })
+        formats.append(
+            {
+                "type": "code",
+                "start": match.start(),
+                "end": match.end(),
+                "content": match.group(1),
+            }
+        )
 
     return formats
 
@@ -439,28 +449,43 @@ def apply_web_markdown_formatting(
             # H1 syntax: text\n---- the match.end() already includes the dashes
             # So the syntax_len is the difference between match end and content
             syntax_len = end - start - len(content)
-            offset_map[start] = (start - current_offset, start - current_offset + len(content))
+            offset_map[start] = (
+                start - current_offset,
+                start - current_offset + len(content),
+            )
             current_offset += syntax_len
         elif fmt_type == "bold":
             syntax_len = len(f"**{content}**") - len(content)
-            offset_map[start] = (start - current_offset, start - current_offset + len(content))
+            offset_map[start] = (
+                start - current_offset,
+                start - current_offset + len(content),
+            )
             current_offset += syntax_len
         elif fmt_type == "italic":
             syntax_len = len(f"_{content}_") - len(content)
-            offset_map[start] = (start - current_offset, start - current_offset + len(content))
+            offset_map[start] = (
+                start - current_offset,
+                start - current_offset + len(content),
+            )
             current_offset += syntax_len
         elif fmt_type == "link":
             syntax_len = len(fmt["content"] + fmt.get("url", "")) + 4
-            offset_map[start] = (start - current_offset, start - current_offset + len(content))
+            offset_map[start] = (
+                start - current_offset,
+                start - current_offset + len(content),
+            )
             current_offset += syntax_len
         elif fmt_type == "code":
             syntax_len = len(f"`{content}`") - len(content)
-            offset_map[start] = (start - current_offset, start - current_offset + len(content))
+            offset_map[start] = (
+                start - current_offset,
+                start - current_offset + len(content),
+            )
             current_offset += syntax_len
 
     # Now apply formatting in correct order (forward iteration)
     formats_sorted = parse_markdown_from_web(text)
-    formats_sorted.sort(key=lambda x: x['start'])
+    formats_sorted.sort(key=lambda x: x["start"])
 
     # Create a list to accumulate offset changes
     cumulative_offset = 0
@@ -476,7 +501,9 @@ def apply_web_markdown_formatting(
             # H1: text\n---- becomes just text
             end = start + len(content)
             # The cumulative offset is the difference between original end and new end
-            original_syntax_len = fmt["end"] - fmt["start"] - len(fmt["content"])
+            original_syntax_len = (
+                fmt["end"] - fmt["start"] - len(fmt["content"])
+            )
             cumulative_offset += original_syntax_len
         elif fmt_type == "bold":
             end = start + len(content)
@@ -555,23 +582,28 @@ def format_comment_on_change(text_edit: QTextEdit) -> None:
     """Format QTextDocument to highlight mentions starting with @.
 
     Any word starting with @ will be formatted in red.
+    Preserves checkbox formatting (CHECKBOX_FORMAT_TYPE).
     """
+    # Import here to avoid circular dependency
+    from .checkbox_handler import CHECKBOX_FORMAT_TYPE
+
     text_edit.document().blockSignals(True)
 
     pal = get_ayon_style().model.base_palette
     document = text_edit.document()
     cursor = text_edit.textCursor()
-    fmt = cursor.charFormat()
 
-    # Create a format for red text
-    user_format = QTextCharFormat(fmt)
+    # Create minimal mention/link formats — only mention-specific properties
+    # are set so that mergeCharFormat preserves user styles (bold, italic, etc.)
+    user_format = QTextCharFormat()
     user_format.setForeground(pal.link())
-    url_format = QTextCharFormat(fmt)
+    url_format = QTextCharFormat()
     url_format.setForeground(pal.link())
     url_format.setFontUnderline(True)
 
-    # Create a format for normal text
-    normal_format = QTextCharFormat()
+    # Track link colour and default text brush for selective clearing
+    link_color = pal.link().color()
+    default_text_brush = pal.text()
 
     # Get all text from document
     md = document.toMarkdown()
@@ -587,9 +619,31 @@ def format_comment_on_change(text_edit: QTextEdit) -> None:
     p_all = f"{p_user}|{p_version}|{p_task}|{p_link}|{p_raw_link}"
     matches = list(re.finditer(p_all, md))
 
-    # Clear all formatting first
-    cursor.select(QTextCursor.SelectionType.Document)
-    cursor.setCharFormat(normal_format)
+    # Clear only mention/link-related formatting so that user-applied styles
+    # (bold, italic, heading, code, background, font family, etc.) are
+    # preserved across keystrokes.
+    text = document.toPlainText()
+    for i in range(len(text)):
+        cursor.setPosition(i)
+        cursor.setPosition(i + 1, QTextCursor.MoveMode.KeepAnchor)
+        char_fmt = cursor.charFormat()
+        # Skip checkbox objects — preserve their formatting entirely
+        if char_fmt.objectType() == CHECKBOX_FORMAT_TYPE:
+            continue
+        # Only reset properties that were set by mention/link formatting
+        has_mention_fmt = (
+            char_fmt.isAnchor()
+            or char_fmt.fontUnderline()
+            or char_fmt.foreground().color() == link_color
+        )
+        if has_mention_fmt:
+            clear_fmt = QTextCharFormat()
+            clear_fmt.setAnchor(False)
+            clear_fmt.setAnchorHref("")
+            clear_fmt.setFontUnderline(False)
+            if char_fmt.foreground().color() == link_color:
+                clear_fmt.setForeground(default_text_brush)
+            cursor.mergeCharFormat(clear_fmt)
 
     # We parsed the markdown but the cursor if using the plain text, so we
     # need to keep track of the number of extra markdown characters to keep
@@ -611,25 +665,25 @@ def format_comment_on_change(text_edit: QTextEdit) -> None:
                         QTextCursor.MoveMode.KeepAnchor,
                     )
 
-                cursor.setCharFormat(user_format)
+                cursor.mergeCharFormat(user_format)
             elif key == "version":
                 cursor.setPosition(match.start())
                 cursor.setPosition(
                     match.end(), QTextCursor.MoveMode.KeepAnchor
                 )
-                cursor.setCharFormat(user_format)
+                cursor.mergeCharFormat(user_format)
             elif key == "task":
                 cursor.setPosition(match.start())
                 cursor.setPosition(
                     match.end(), QTextCursor.MoveMode.KeepAnchor
                 )
-                cursor.setCharFormat(user_format)
+                cursor.mergeCharFormat(user_format)
             if key == "raw_link":
                 cursor.setPosition(match.start())
                 cursor.setPosition(
                     match.end(), QTextCursor.MoveMode.KeepAnchor
                 )
-                cursor.setCharFormat(user_format)
+                cursor.mergeCharFormat(user_format)
             elif key == "link":
                 p0 = match.start() - xtra
                 cursor.setPosition(p0)
@@ -637,7 +691,7 @@ def format_comment_on_change(text_edit: QTextEdit) -> None:
                 p1 = (match.start() - xtra) + len(link_name)
                 cursor.setPosition(p1, QTextCursor.MoveMode.KeepAnchor)
                 xtra += len(val) - len(link_name) + 1
-                cursor.setCharFormat(url_format)
+                cursor.mergeCharFormat(url_format)
 
     # Restore original cursor position
     text_edit.document().blockSignals(False)

--- a/client/ayon_ui_qt/components/container.py
+++ b/client/ayon_ui_qt/components/container.py
@@ -5,9 +5,10 @@ from enum import Enum
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLayout, QLayoutItem, QWidget
 
+from ..utils import clear_layout
+from ..variants import QFrameVariants
 from .frame import AYFrame
 from .layouts import AYFlowLayout, AYGridLayout, AYHBoxLayout, AYVBoxLayout
-from ..variants import QFrameVariants
 
 
 class AYContainer(AYFrame):
@@ -113,6 +114,9 @@ class AYContainer(AYFrame):
         if isinstance(self._layout, AYGridLayout):
             raise NotImplementedError
         return self._layout.itemAt(index)  # type: ignore
+
+    def clear(self):
+        clear_layout(self._layout)
 
 
 if __name__ == "__main__":

--- a/client/ayon_ui_qt/components/text_box.py
+++ b/client/ayon_ui_qt/components/text_box.py
@@ -551,6 +551,31 @@ class AYTextEditor(AYTextEdit):
         self.setTextCursor(cursor)
         self.setFocus()
 
+    def paintEvent(self, event) -> None:
+        """Override paintEvent to make sure the placeholder text is not
+        displayed when an empty list is added to an empty document."""
+        if (
+            self.placeholderText()
+            and self.document().isEmpty()
+            and self._has_list_block()
+        ):
+            self._suppress_formatting = True
+            saved = self.placeholderText()
+            super().setPlaceholderText("")
+            super().paintEvent(event)
+            super().setPlaceholderText(saved)
+            self._suppress_formatting = False
+            return
+        super().paintEvent(event)
+
+    def _has_list_block(self) -> bool:
+        block = self.document().begin()
+        while block.isValid():
+            if block.textList() is not None:
+                return True
+            block = block.next()
+        return False
+
 
 NO_CATEGORY = {
     "text": "Category",

--- a/client/ayon_ui_qt/components/text_box.py
+++ b/client/ayon_ui_qt/components/text_box.py
@@ -42,12 +42,15 @@ from .checkbox_handler import (
 )
 from .combo_box import AYComboBox
 from .comment_completion import (
+    apply_code_block_backgrounds,
     format_comment_on_change,
     on_completer_activated,
     on_completer_key_press,
     on_completer_text_changed,
     on_users_updated,
     setup_user_completer,
+    CODE_FG,
+    CODE_BG
 )
 from .container import AYContainer
 from .layouts import AYHBoxLayout, AYVBoxLayout
@@ -139,6 +142,7 @@ class AYTextEditor(AYTextEdit):
         """
         if not self._suppress_formatting:
             format_comment_on_change(self)
+            apply_code_block_backgrounds(self)
 
     def _on_text_changed(self) -> None:
         """Handle text changes to show/hide completer."""
@@ -260,6 +264,7 @@ class AYTextEditor(AYTextEdit):
             self._checkbox_handler.parse_and_render(md)
         else:
             self.document().setMarkdown(md, MD_DIALECT)
+        apply_code_block_backgrounds(self)
 
     def as_markdown(self) -> str:
         """Get the content as GitHub-flavored markdown.
@@ -456,8 +461,8 @@ class AYTextEditor(AYTextEdit):
                 fmt.setFontFamilies(
                     ["Courier New", "Menlo", "Monaco", "monospace"]
                 )
-                fmt.setBackground(QColor("#1e1e1e"))
-                fmt.setForeground(QColor("#d4d4d4"))
+                fmt.setBackground(CODE_BG)
+                fmt.setForeground(CODE_FG)
 
             if cursor.hasSelection():
                 cursor.mergeCharFormat(fmt)

--- a/client/ayon_ui_qt/components/text_box.py
+++ b/client/ayon_ui_qt/components/text_box.py
@@ -7,6 +7,7 @@ from functools import partial
 from qtpy import QtWidgets
 from qtpy.QtCore import (
     QObject,
+    QPoint,
     Qt,
     Signal,  # type: ignore
     Slot,  # type: ignore
@@ -16,9 +17,11 @@ from qtpy.QtGui import (
     QFont,
     QPalette,
     QPixmap,
+    QTextBlockFormat,
+    QTextCharFormat,
     QTextCursor,
     QTextDocument,
-    QTextFrameFormat,
+    QTextListFormat,
 )
 from qtpy.QtWidgets import (
     QLabel,
@@ -31,6 +34,12 @@ from .. import get_ayon_style
 from ..data_models import CommentCategory, ProjectData, User
 from ..variants import QFrameVariants, QTextEditVariants
 from .buttons import AYButton
+from .checkbox_handler import (
+    CHECKBOX_FORMAT_TYPE,
+    CHECKBOX_CHECKED_PROP,
+    CHECKBOX_INDEX_PROP,
+    CheckboxHandler,
+)
 from .combo_box import AYComboBox
 from .comment_completion import (
     format_comment_on_change,
@@ -53,6 +62,7 @@ class AYTextEditor(AYTextEdit):
     Variants = QTextEditVariants
 
     submitted = Signal()  # Signal emitted when Ctrl+Enter is pressed
+    checklist_changed = Signal()  # Signal emitted when checkbox state changes
 
     def __init__(
         self,
@@ -68,14 +78,30 @@ class AYTextEditor(AYTextEdit):
         self._read_only: bool = read_only
         self._user_list: list[User] = user_list or []
         self._variant_str: str = variant.value
+        self._checkbox_handler: CheckboxHandler | None = None
+        # Guard flag: when True, format_comment_on_change is a no-op.
+        self._suppress_formatting: bool = False
 
         super().__init__(*args, variant=variant, **kwargs)
         self.setStyle(get_ayon_style())
+        # Enable mouse tracking on viewport to receive mouseMoveEvent
+        self.viewport().setMouseTracking(True)
+
+        self.document().setIndentWidth(22)  # pixels per indent level
 
         if self.num_lines:
-            self.setFixedHeight(
-                self.fontMetrics().lineSpacing() * self.num_lines + 8
+            doc = self.document()
+            fm = self.fontMetrics()
+            frame_w = self.frameWidth()
+            cm = self.contentsMargins()
+            height = (
+                fm.lineSpacing() * self.num_lines
+                + int(doc.documentMargin()) * 2
+                + frame_w * 2
+                + cm.top()
+                + cm.bottom()
             )
+            self.setFixedHeight(height)
 
         self.setSizePolicy(
             QSizePolicy.Policy.Expanding,
@@ -102,9 +128,17 @@ class AYTextEditor(AYTextEdit):
             self._on_text_changed,
         )
 
-        self.document().contentsChanged.connect(
-            lambda: format_comment_on_change(self)
-        )
+        self.document().contentsChanged.connect(self._on_contents_changed)
+
+    def _on_contents_changed(self) -> None:
+        """Forward contentsChanged to format_comment_on_change.
+
+        Skipped when ``_suppress_formatting`` is True so that checkbox
+        insertion code can mutate the document without triggering a
+        full re-format pass.
+        """
+        if not self._suppress_formatting:
+            format_comment_on_change(self)
 
     def _on_text_changed(self) -> None:
         """Handle text changes to show/hide completer."""
@@ -120,62 +154,238 @@ class AYTextEditor(AYTextEdit):
             event.accept()
             return
 
+        # ctrl/cmd-enter to submit
         if (
             event.key() in {Qt.Key.Key_Return, Qt.Key.Key_Enter}
             and event.modifiers() & Qt.KeyboardModifier.ControlModifier
         ):
             self.submitted.emit()
 
+        # Auto-continue checkbox on Enter
+        if (
+            event.key() in {Qt.Key.Key_Return, Qt.Key.Key_Enter}
+            and self._checkbox_handler
+            and self._checkbox_handler.has_checkboxes()
+        ):
+            cursor = self.textCursor()
+            block_text = cursor.block().text()
+
+            if "\ufffc" in block_text:
+                # Extract text after the checkbox object char
+                parts = block_text.split("\ufffc", 1)
+                after_checkbox = parts[1].strip() if len(parts) > 1 else ""
+
+                if not after_checkbox:
+                    # Empty checkbox line → end the list
+                    # Remove the checkbox content from current block
+                    cursor.movePosition(
+                        QTextCursor.MoveOperation.StartOfBlock,
+                        QTextCursor.MoveMode.MoveAnchor,
+                    )
+                    cursor.movePosition(
+                        QTextCursor.MoveOperation.EndOfBlock,
+                        QTextCursor.MoveMode.KeepAnchor,
+                    )
+                    cursor.removeSelectedText()
+                    # Remove the last checkbox from handler
+                    self._checkbox_handler.remove_last_checkbox()
+                    # Insert a plain newline
+                    super().keyPressEvent(event)
+                    return
+
+                # Non-empty checkbox line → insert new checkbox
+                event.accept()
+                self._suppress_formatting = True
+
+                cursor.beginEditBlock()
+                cursor.movePosition(QTextCursor.MoveOperation.EndOfBlock)
+                cursor.insertBlock()
+                self._insert_checkbox_at_cursor(cursor)
+                cursor.endEditBlock()
+
+                self._suppress_formatting = False
+                self.setTextCursor(cursor)
+                return
+
         super().keyPressEvent(event)
 
-    def set_style(self, style):
+    def _setup_checkbox_handler(self) -> None:
+        """Initialize checkbox handler if not already done."""
+        if self._checkbox_handler is None:
+            self._checkbox_handler = CheckboxHandler(self)
+            self._checkbox_handler.checklist_changed.connect(
+                self._on_checklist_changed
+            )
+
+    def _on_checklist_changed(self) -> None:
+        """Handle checkbox state changes."""
+        self.checklist_changed.emit()
+
+    def _insert_checkbox_at_cursor(self, cursor: QTextCursor) -> None:
+        """Insert a new unchecked checkbox object at the cursor position.
+
+        Inserts a two-space prefix, the custom checkbox object character
+        (``\\ufffc``), and a trailing space, then records the document
+        position on the :class:`CheckboxItem` for fast hit-testing.
+        The checkbox handler must already be initialised via
+        :meth:`_setup_checkbox_handler`.
+
+        Args:
+            cursor: Cursor at the insertion point; advanced past the
+                inserted characters on return.
+        """
+        assert self._checkbox_handler is not None
+        new_item = self._checkbox_handler.add_checkbox()
+        fmt = QTextCharFormat()
+        fmt.setObjectType(CHECKBOX_FORMAT_TYPE)
+        fmt.setProperty(CHECKBOX_CHECKED_PROP, False)
+        fmt.setProperty(CHECKBOX_INDEX_PROP, new_item.index)
+        fmt.setVerticalAlignment(
+            QTextCharFormat.VerticalAlignment.AlignBaseline
+        )
+        cursor.insertText("  ")
+        new_item.doc_position = cursor.position()
+        cursor.insertText("\ufffc", fmt)
+        cursor.insertText(" ")
+
+    def set_markdown(self, md: str) -> None:
+        """Set markdown content with checkbox support.
+
+        Args:
+            md: Markdown text to display
+        """
+        if CheckboxHandler.contains_checkboxes(md):
+            self._setup_checkbox_handler()
+            assert self._checkbox_handler is not None
+            self._checkbox_handler.parse_and_render(md)
+        else:
+            self.document().setMarkdown(md, MD_DIALECT)
+
+    def as_markdown(self) -> str:
+        """Get the content as GitHub-flavored markdown.
+
+        Returns:
+            Markdown string.
+        """
+        if self._checkbox_handler and self._checkbox_handler.has_checkboxes():
+            return self._checkbox_handler.to_markdown()
+        return self.document().toMarkdown(MD_DIALECT)
+
+    def _is_checkbox_at_cursor(
+        self, click_pos: QPoint
+    ) -> tuple[bool, int | None]:
+        """Check if a click position hits a checkbox bounding rect.
+
+        Delegates to :meth:`CheckboxHandler.find_checkbox_at_click` which
+        uses stored document positions instead of scanning the full text.
+
+        Args:
+            click_pos: QPoint from event.pos(), viewport coords.
+
+        Returns:
+            Tuple of (is_checkbox, document_position_for_lookup).
+        """
+        if not self._checkbox_handler:
+            return False, None
+
+        # Account for scroll offset
+        scroll_offset = QPoint(
+            -self.horizontalScrollBar().value(),
+            -self.verticalScrollBar().value(),
+        )
+        result = self._checkbox_handler.find_checkbox_at_click(
+            click_pos, scroll_offset
+        )
+        if result is None:
+            return False, None
+        return result
+
+    def mousePressEvent(self, event) -> None:
+        """Handle mouse press events for checkboxes.
+
+        Checkboxes can be toggled even in read-only mode.
+        """
+        is_cb, cb_pos = self._is_checkbox_at_cursor(event.pos())
+        if is_cb and cb_pos is not None:
+            assert self._checkbox_handler is not None  # implied by is_cb==True
+            checkbox_idx = self._checkbox_handler.get_checkbox_at_position(
+                cb_pos
+            )
+            if checkbox_idx is not None:
+                self._checkbox_handler.toggle_checkbox(checkbox_idx)
+                self.viewport().update()
+                event.accept()
+                return
+
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        """Show arrow cursor over checkboxes, hand over links, I-beam else."""
+        pos = event.pos()
+        cursor = self.cursorForPosition(pos)
+        fmt = cursor.charFormat()
+        if fmt.objectType() == CHECKBOX_FORMAT_TYPE:
+            self.viewport().setCursor(Qt.CursorShape.ArrowCursor)
+        elif fmt.isAnchor():
+            self.viewport().setCursor(Qt.CursorShape.PointingHandCursor)
+        else:
+            self.viewport().setCursor(Qt.CursorShape.IBeamCursor)
+        super().mouseMoveEvent(event)
+
+    def set_style(self, style: str) -> None:
+        """Apply a character style to the current selection or cursor.
+
+        Styles are merged with the existing character formatting so that
+        multiple styles (e.g. bold + italic) can be combined without
+        removing previously applied styles.
+
+        Args:
+            style: Style identifier string (e.g. ``"stl_bold"``).
+        """
         cursor = self.textCursor()
 
-        # Disconnect the format_comment_on_change to prevent re-formatting
-        self.document().contentsChanged.disconnect()
-        self._applying_style = True
+        # Suppress formatting during style application
+        self._suppress_formatting = True
 
         cursor.beginEditBlock()
 
         if style == "stl_bold":
-            # Toggle bold for current format or set it for new text
-            fmt = cursor.charFormat()
+            # Toggle bold, preserving all other formatting
+            current_weight = cursor.charFormat().fontWeight()
             new_weight = (
                 QFont.Weight.Normal
-                if fmt.fontWeight() == QFont.Weight.Bold
+                if current_weight == QFont.Weight.Bold
                 else QFont.Weight.Bold
             )
+            fmt = QTextCharFormat()
             fmt.setFontWeight(new_weight)
 
-            # Apply the format to current selection OR set as current format
-            # for next text
             if cursor.hasSelection():
-                cursor.setCharFormat(fmt)
+                cursor.mergeCharFormat(fmt)
             else:
-                # Set as the current format for subsequent typing
-                self.setCurrentCharFormat(fmt)
+                self.mergeCurrentCharFormat(fmt)
 
-            # Ensure the cursor maintains this format
             self.setTextCursor(cursor)
 
         elif style == "stl_italic":
-            fmt = cursor.charFormat()
-            new_italic = not fmt.fontItalic()
+            # Toggle italic, preserving all other formatting
+            new_italic = not cursor.charFormat().fontItalic()
+            fmt = QTextCharFormat()
             fmt.setFontItalic(new_italic)
 
             if cursor.hasSelection():
-                cursor.setCharFormat(fmt)
+                cursor.mergeCharFormat(fmt)
             else:
-                self.setCurrentCharFormat(fmt)
+                self.mergeCurrentCharFormat(fmt)
 
             self.setTextCursor(cursor)
 
         elif style == "stl_h1":
-            fmt = cursor.charFormat()
+            # Toggle heading size, preserving all other formatting
             base_size = self.font().pointSize()
-            current_size = fmt.fontPointSize()
+            current_size = cursor.charFormat().fontPointSize()
 
-            # Toggle header formatting
+            fmt = QTextCharFormat()
             if current_size > base_size:  # Already a header
                 fmt.setFontPointSize(base_size)
                 fmt.setFontWeight(QFont.Weight.Normal)
@@ -184,9 +394,9 @@ class AYTextEditor(AYTextEdit):
                 fmt.setFontWeight(QFont.Weight.Bold)
 
             if cursor.hasSelection():
-                cursor.setCharFormat(fmt)
+                cursor.mergeCharFormat(fmt)
             else:
-                self.setCurrentCharFormat(fmt)
+                self.mergeCurrentCharFormat(fmt)
 
             self.setTextCursor(cursor)
 
@@ -202,15 +412,15 @@ class AYTextEditor(AYTextEdit):
 
             def _make_link():
                 link = field.text()
-                fmt = self.currentCharFormat()
+                fmt = QTextCharFormat()
                 fmt.setAnchor(True)
                 fmt.setAnchorHref(link)
                 fmt.setFontUnderline(True)
 
                 if cursor.hasSelection():
-                    cursor.setCharFormat(fmt)
+                    cursor.mergeCharFormat(fmt)
                 else:
-                    self.setCurrentCharFormat(fmt)
+                    self.mergeCurrentCharFormat(fmt)
 
                 field.close()
                 field.deleteLater()
@@ -226,37 +436,120 @@ class AYTextEditor(AYTextEdit):
             field.returnPressed.connect(_make_link)
 
         elif style == "stl_code":
-            frame_fmt = QTextFrameFormat()
-            cursor.insertFrame(frame_fmt)
-            print("IMPLEMENT ME !")
+            # Detect if already in code style
+            is_code = cursor.charFormat().fontFixedPitch()
+            fmt = QTextCharFormat()
+
+            if is_code:
+                # Toggle off: revert code-specific properties to widget defaults
+                fmt.setFontFixedPitch(False)
+                fmt.setFontFamilies([self.font().family()])
+                fmt.setBackground(
+                    self.palette().color(QPalette.ColorRole.Base)
+                )
+                fmt.setForeground(
+                    self.palette().color(QPalette.ColorRole.Text)
+                )
+            else:
+                # Toggle on: apply code style
+                fmt.setFontFixedPitch(True)
+                fmt.setFontFamilies(
+                    ["Courier New", "Menlo", "Monaco", "monospace"]
+                )
+                fmt.setBackground(QColor("#1e1e1e"))
+                fmt.setForeground(QColor("#d4d4d4"))
+
+            if cursor.hasSelection():
+                cursor.mergeCharFormat(fmt)
+            else:
+                self.mergeCurrentCharFormat(fmt)
+
+            self.setTextCursor(cursor)
 
         cursor.endEditBlock()
-        self._applying_style = False
-        self.document().contentsChanged.connect(
-            lambda: format_comment_on_change(self)
-        )
+        self._suppress_formatting = False
+        self.setFocus()
 
-    def set_format(self, format):
-        """Set up the bullet/numbered/checklist formatting."""
+    def _insert_fmt_checklist(self) -> None:
+        """Insert an unchecked checklist checkbox at the current cursor.
+
+        If the cursor is on a bullet or numbered list line, the list
+        item is converted into a checkbox line, preserving its text.
+        Otherwise inserts on the current (empty) block, or on a new
+        block inserted above when the current line is non-empty.
+        """
+        self._setup_checkbox_handler()
+        assert self._checkbox_handler is not None
+
+        self._suppress_formatting = True
         cursor = self.textCursor()
         cursor.beginEditBlock()
-        # Select all and delete to remove placeholder
-        cursor.movePosition(QTextCursor.MoveOperation.Start)
-        if format == "fmt_bullet":
-            # Apply bullet list formatting
-            self.document().setMarkdown("- ", MD_DIALECT)
-        elif format == "fmt_number":
-            # Apply numbered list formatting
-            self.document().setMarkdown("1. ", MD_DIALECT)
-        elif format == "fmt_checklist":
-            # Apply checklist formatting
-            self.document().setMarkdown("- [ ] ", MD_DIALECT)
 
-        cursor.insertText(" ")
+        block = cursor.block()
+        text_list = block.textList()
+
+        if text_list is not None:
+            # Convert existing list item to checkbox.
+            # Qt stores block text WITHOUT the list marker,
+            # so block.text() gives us the clean content.
+            line_text = block.text().strip()
+
+            # Remove this block from the QTextList
+            text_list.remove(block)
+
+            # Reset the block indent that the QTextList left behind
+            block_fmt = cursor.blockFormat()
+            block_fmt.setIndent(0)
+            cursor.setBlockFormat(block_fmt)
+
+            # Select all content in the block and delete it
+            cursor.movePosition(QTextCursor.MoveOperation.StartOfBlock)
+            cursor.movePosition(
+                QTextCursor.MoveOperation.EndOfBlock,
+                QTextCursor.MoveMode.KeepAnchor,
+            )
+            cursor.removeSelectedText()
+
+            # Insert checkbox + original text
+            self._insert_checkbox_at_cursor(cursor)
+            cursor.insertText(line_text)
+        else:
+            # Original behavior for plain text
+            cursor.movePosition(QTextCursor.MoveOperation.StartOfBlock)
+            if cursor.block().text().strip():
+                cursor.insertBlock()
+                cursor.movePosition(QTextCursor.MoveOperation.PreviousBlock)
+                cursor.movePosition(QTextCursor.MoveOperation.StartOfBlock)
+
+            self._insert_checkbox_at_cursor(cursor)
+
         cursor.endEditBlock()
-        # Move cursor to end
-        cursor.movePosition(QTextCursor.MoveOperation.End)
+        self._suppress_formatting = False
         self.setTextCursor(cursor)
+        self.setFocus()
+
+    def set_format(self, format: str) -> None:
+        """Set up the bullet/numbered/checklist formatting."""
+        if format == "fmt_checklist":
+            self._insert_fmt_checklist()
+            return
+
+        cursor = self.textCursor()
+        cursor.beginEditBlock()
+        cursor.movePosition(QTextCursor.MoveOperation.StartOfBlock)
+
+        if format == "fmt_bullet":
+            list_fmt = QTextListFormat()
+            list_fmt.setStyle(QTextListFormat.Style.ListDisc)
+            cursor.createList(list_fmt)
+        elif format == "fmt_number":
+            list_fmt = QTextListFormat()
+            list_fmt.setStyle(QTextListFormat.Style.ListDecimal)
+            cursor.createList(list_fmt)
+
+        cursor.endEditBlock()
+        self.setTextCursor(cursor)
+        self.setFocus()
 
 
 NO_CATEGORY = {
@@ -409,8 +702,7 @@ class AYTextBox(AYContainer):
     format_icons = {
         "fmt_number": "format_list_numbered",
         "fmt_bullet": "format_list_bulleted",
-        # TODO: Implement checklist editing and visualizing before enabling
-        # "fmt_checklist": "checklist",
+        "fmt_checklist": "checklist",
     }
     mention_map = {
         "person": "@",
@@ -545,12 +837,13 @@ class AYTextBox(AYContainer):
 
     def _on_comment_clicked(self) -> None:
         """Handle comment button click and emit signal with markdown content."""
-        markdown_content = self.edit_field.document().toMarkdown(MD_DIALECT)
+        markdown_content = self.edit_field.as_markdown()
         self.signals.comment_submitted.emit(
             markdown_content, self.category, self._file_attachments
         )
         self.edit_field.clear()
-        self.com_cat.setCurrentIndex(0)
+        if self.show_categories:
+            self.com_cat.setCurrentIndex(0)
         self.clear_annotation_attachment()
         self.clear_file_attachments()
 
@@ -862,7 +1155,12 @@ class AYTextBox(AYContainer):
         self.add_layout(self._build_lower_bar())
 
     def set_markdown(self, md: str):
-        self.edit_field.document().setMarkdown(md, MD_DIALECT)
+        """Set markdown content with checkbox support.
+
+        Args:
+            md: Markdown text to display
+        """
+        self.edit_field.set_markdown(md)
 
 
 # TEST ------------------------------------------------------------------------

--- a/client/ayon_ui_qt/data_models.py
+++ b/client/ayon_ui_qt/data_models.py
@@ -3,6 +3,16 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, List, Optional
+from enum import IntEnum, auto
+
+
+class ActivityCategory(IntEnum):
+    ALL = auto()
+    COMMENT = auto()
+    STATUS_CHANGE = auto()
+    VERSION_PUBLISH = auto()
+    CHECKLIST = auto()
+    DETAILS = auto()
 
 
 def short_date(date_str: str) -> str:
@@ -55,7 +65,9 @@ class StatusChangeModel:
     new_status: str = ""
     date: str = ""
     short_date: str = field(init=False, hash=False)
-    type: str = field(init=False, default="status.change", hash=False)
+    type: ActivityCategory = field(
+        init=False, default=ActivityCategory.STATUS_CHANGE, hash=False
+    )
 
     def __post_init__(self):
         self.short_date = short_date(self.date)
@@ -71,7 +83,9 @@ class VersionPublishModel:
     product: str = ""
     date: str = ""
     short_date: str = field(init=False, hash=False)
-    type: str = field(init=False, default="version.publish", hash=False)
+    type: ActivityCategory = field(
+        init=False, default=ActivityCategory.VERSION_PUBLISH, hash=False
+    )
 
     def __post_init__(self):
         self.short_date = short_date(self.date)
@@ -92,6 +106,7 @@ class FileModel:
     Attachments could be images, there could be also preview available for
     them.
     """
+
     id: str
     mime: str
     local_path: str = ""
@@ -110,9 +125,13 @@ class CommentModel:
     category_color: str = ""
     comment_date: str = ""
     short_date: str = field(init=False, hash=False)
-    type: str = field(init=False, default="comment", hash=False)
+    type: ActivityCategory = field(
+        init=False, default=ActivityCategory.COMMENT, hash=False
+    )
     files: list[FileModel] = field(default_factory=list, hash=False)
-    annotations: list[AnnotationModel] = field(default_factory=list, hash=False)
+    annotations: list[AnnotationModel] = field(
+        default_factory=list, hash=False
+    )
 
     def __post_init__(self):
         """Set the date if not set and compute the short date."""
@@ -163,6 +182,7 @@ class Team:
 @dataclass
 class CommentCategory:
     """Model for powerpack `activity_categories` settings"""
+
     name: str
     color: str
     access: dict[str, Any]
@@ -176,9 +196,8 @@ class ProjectData:
     users: List[User]
     teams: List[Team]
     anatomy: dict[str, Any]
-    comment_category : List[CommentCategory]
+    comment_category: List[CommentCategory]
     current_user: Optional[User]
-
 
     @staticmethod
     def not_set():
@@ -189,7 +208,7 @@ class ProjectData:
             teams=[],
             anatomy={},
             comment_category=[],
-            current_user=None
+            current_user=None,
         )
 
 
@@ -227,7 +246,7 @@ class VersionData:
             assignees=[],
             attrib={},
             thumbnail_id=None,
-            thumbnail_local_path=None
+            thumbnail_local_path=None,
         )
 
 

--- a/client/ayon_ui_qt/data_models.py
+++ b/client/ayon_ui_qt/data_models.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import Flag, auto
 from typing import Any, List, Optional
-from enum import IntEnum, auto
+
+RE_HAS_CHECKLIST = re.compile(r"\s*[-*+]\s+\[[xX ]\]\s*")
 
 
-class ActivityCategory(IntEnum):
-    ALL = auto()
-    COMMENT = auto()
+class ActivityCategory(Flag):
+    COMMENT = 1
     STATUS_CHANGE = auto()
     VERSION_PUBLISH = auto()
     CHECKLIST = auto()
     DETAILS = auto()
+    ALL = COMMENT | STATUS_CHANGE | VERSION_PUBLISH | CHECKLIST
 
 
 def short_date(date_str: str) -> str:
@@ -120,7 +123,7 @@ class CommentModel:
     user_full_name: str = ""
     user_name: str = ""
     user_src: str = ""
-    comment: str = ""
+    comment: str = ""  # type: ignore
     category: str = ""
     category_color: str = ""
     comment_date: str = ""
@@ -132,6 +135,7 @@ class CommentModel:
     annotations: list[AnnotationModel] = field(
         default_factory=list, hash=False
     )
+    _comment: str = field(init=False, repr=False)
 
     def __post_init__(self):
         """Set the date if not set and compute the short date."""
@@ -139,6 +143,17 @@ class CommentModel:
             self.comment_date = datetime.now(timezone.utc).isoformat()
 
         self.short_date = short_date(self.comment_date)
+
+    @property
+    def comment(self):  # noqa: F811
+        return self._comment
+
+    @comment.setter
+    def comment(self, value: str):
+        """Check if the comment contains a checklist."""
+        if re.search(RE_HAS_CHECKLIST, str(value)):
+            self.type = ActivityCategory.COMMENT | ActivityCategory.CHECKLIST
+        self._comment = value
 
 
 # -----------------------------------------------------------------------------
@@ -258,3 +273,44 @@ if __name__ == "__main__":
     print(f"v ={v}  hash(v) = {hash(v)}")
     s = StatusChangeModel()
     print(f"s ={s}  hash(s) = {hash(s)}")
+    #  test checkbox detection
+    print()
+    comment = "This contains a checklist\n\n- [ ] do this\n- [x] done this\n"
+    c = CommentModel(comment=comment)
+    print(f"checklist test:\n - comment: {c.comment!r}\n - type: {c.type!r}")
+    comment = "This does not contains a checklist\n\n"
+    c = CommentModel(comment=comment)
+    print(f"checklist test:\n - comment: {c.comment!r}\n - type: {c.type!r}")
+    print()
+    s = ActivityCategory.COMMENT
+    print(f"s = {s!r}")
+    print(f"s == ActivityCategory.COMMENT -> {s == ActivityCategory.COMMENT}")
+    print(
+        f"s == ActivityCategory.CHECKLIST -> {s == ActivityCategory.CHECKLIST}"
+    )
+    ch = ActivityCategory.COMMENT | ActivityCategory.CHECKLIST
+    print(f"ch = {ch!r}")
+    print(
+        f"ch == ActivityCategory.COMMENT -> {ch == ActivityCategory.COMMENT}"
+    )
+    print(
+        f"ch == ActivityCategory.CHECKLIST -> {ch == ActivityCategory.CHECKLIST}"
+    )
+    print(
+        f"ch & ActivityCategory.CHECKLIST -> {ch & ActivityCategory.CHECKLIST}"
+    )
+    print(f"ch & ActivityCategory.COMMENT -> {ch & ActivityCategory.COMMENT}")
+    print(
+        f"ch & ActivityCategory.VERSION_PUBLISH -> {ch & ActivityCategory.VERSION_PUBLISH}"
+    )
+    print()
+    for filter in list(ActivityCategory) + [
+        ActivityCategory.COMMENT | ActivityCategory.CHECKLIST
+    ]:
+        print(f"filter = {filter!r} -----------------------------------------")
+        for cat in ActivityCategory:
+            # print(f"{cat.name} -> {cat.value}")
+            print(
+                f"bool({cat.name} & filter) -> {bool(cat & filter)}"
+            )
+            # print(f"filter & {cat.name}  == {cat.name} -> {filter & cat == cat}")

--- a/plans/checkbox-in-markdown.md
+++ b/plans/checkbox-in-markdown.md
@@ -1,0 +1,330 @@
+# Markdown Checklist Implementation Plan
+
+## Overview
+
+This document outlines the implementation plan for adding editable, styled checkboxes to [`AYCommentField`](client/ayon_ui_qt/components/comment.py:191). The checkboxes should:
+
+1. Be rendered with Material icons (unchecked: white `radio_button_unchecked`, checked: green `check_circle`)
+2. Be interactive even when the field is read-only
+3. Emit a `checklist_changed` signal when toggled
+4. Support GitHub-flavored markdown syntax for import/export (`- [ ]` / `- [x]`)
+
+## Technical Challenges
+
+### Qt's Built-in Markdown Limitations
+
+Qt's `QTextDocument.setMarkdown()` does support GitHub-flavored markdown (including task lists), but:
+- The checkbox styling is limited to the default system checkboxes
+- In read-only mode (`QTextEdit.setReadOnly(True)`), checkboxes become non-interactive
+- Custom styling of checkboxes rendered within the document is not straightforward
+
+### Proposed Solution: QTextObjectInterface
+
+The most robust approach is to use Qt's **QTextObjectInterface** to embed custom widgets/objects directly into the `QTextDocument`. This allows us to:
+
+1. Parse markdown checkboxes (`- [ ]` / `- [x]`)
+2. Replace them with custom inline objects that render Material icons
+3. Handle click events on these objects to toggle state
+4. Maintain a mapping between document positions and checkbox states
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Input
+        MD[Markdown Text]
+    end
+
+    subgraph Parsing
+        P1[Parse checkbox patterns]
+        P2[Extract state and position]
+    end
+
+    subgraph Rendering
+        R1[Create CheckboxTextObject]
+        R2[Insert into QTextDocument]
+        R3[Render with Material icons]
+    end
+
+    subgraph Interaction
+        I1[Mouse click detection]
+        I2[Toggle checkbox state]
+        I3[Emit checklist_changed signal]
+    end
+
+    subgraph Export
+        E1[Reconstruct markdown]
+        E2[as_markdown method]
+    end
+
+    MD --> P1 --> P2 --> R1 --> R2 --> R3
+    R3 --> I1 --> I2 --> I3
+    I2 --> E1 --> E2
+```
+
+## Implementation Components
+
+### 1. CheckboxTextObject Class
+
+A new class implementing `QTextObjectInterface` to render checkboxes as inline objects.
+
+**File:** [`client/ayon_ui_qt/components/checkbox_text_object.py`](client/ayon_ui_qt/components/checkbox_text_object.py) (new file)
+
+```python
+from qtpy.QtCore import QRectF, QSizeF, Qt
+from qtpy.QtGui import QPainter, QTextDocument, QTextFormat, QTextObjectInterface
+from qtpy.QtWidgets import QTextEdit
+
+try:
+    from qtmaterialsymbols import get_icon
+except ImportError:
+    from ..vendor.qtmaterialsymbols import get_icon
+
+
+class CheckboxTextObject:
+    """Custom text object for rendering checkboxes with Material icons."""
+
+    # Custom format type for checkboxes
+    CHECKBOX_FORMAT_TYPE = QTextFormat.ObjectTypes.UserObject + 1
+
+    # Property keys for checkbox data
+    CHECKBOX_CHECKED = 1
+    CHECKBOX_INDEX = 2
+
+    @staticmethod
+    def intrinsicSize(
+        doc: QTextDocument,
+        posInDocument: int,
+        format: QTextFormat,
+    ) -> QSizeF:
+        """Return the size of the checkbox icon."""
+        font = doc.defaultFont()
+        size = font.pointSize() * 1.5  # Scale relative to font
+        return QSizeF(size, size)
+
+    @staticmethod
+    def drawObject(
+        painter: QPainter,
+        rect: QRectF,
+        doc: QTextDocument,
+        posInDocument: int,
+        format: QTextFormat,
+    ) -> None:
+        """Draw the checkbox icon."""
+        is_checked = format.property(CheckboxTextObject.CHECKBOX_CHECKED)
+
+        if is_checked:
+            icon = get_icon("check_circle", color="#4CAF50")  # Green
+        else:
+            icon = get_icon("radio_button_unchecked", color="#FFFFFF")  # White
+
+        pixmap = icon.pixmap(int(rect.width()), int(rect.height()))
+        painter.drawPixmap(rect.topLeft().toPoint(), pixmap)
+```
+
+### 2. CheckboxHandler Class
+
+Manages checkbox state, parsing, and interaction.
+
+**File:** [`client/ayon_ui_qt/components/checkbox_handler.py`](client/ayon_ui_qt/components/checkbox_handler.py) (new file)
+
+```python
+from dataclasses import dataclass
+import re
+from typing import List, Tuple
+
+from qtpy.QtCore import QObject, Signal
+from qtpy.QtGui import QTextCharFormat, QTextCursor, QTextDocument
+
+
+@dataclass
+class CheckboxItem:
+    """Represents a checkbox in the document."""
+    index: int
+    checked: bool
+    text: str
+    start_pos: int  # Position in plain text
+    end_pos: int    # End position of checkbox line
+
+
+class CheckboxHandler(QObject):
+    """Handles checkbox parsing, rendering, and state management."""
+
+    checklist_changed = Signal()  # Emitted when any checkbox is toggled
+
+    # GitHub-flavored markdown checkbox patterns
+    CHECKBOX_PATTERN = re.compile(r'^(\s*[-*+]\s+)\[([xX ])\]\s*(.*)$', re.MULTILINE)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._checkboxes: List[CheckboxItem] = []
+        self._document: QTextDocument = None
+
+    def parse_markdown(self, text: str) -> Tuple[str, List[CheckboxItem]]:
+        """Parse markdown and extract checkbox information.
+
+        Returns:
+            Tuple of (processed text, list of CheckboxItems)
+        """
+        # Implementation details...
+        pass
+
+    def toggle_checkbox(self, index: int) -> None:
+        """Toggle a checkbox by its index."""
+        if 0 <= index < len(self._checkboxes):
+            self._checkboxes[index].checked = not self._checkboxes[index].checked
+            self.checklist_changed.emit()
+
+    def to_markdown(self) -> str:
+        """Reconstruct markdown with current checkbox states."""
+        # Implementation details...
+        pass
+```
+
+### 3. Modifications to AYCommentField
+
+**File:** [`client/ayon_ui_qt/components/comment.py`](client/ayon_ui_qt/components/comment.py:191)
+
+Key changes to [`AYCommentField`](client/ayon_ui_qt/components/comment.py:191):
+
+1. Add `checklist_changed` signal declaration
+2. Instantiate and configure `CheckboxHandler`
+3. Override `mousePressEvent()` to detect checkbox clicks (works even in read-only)
+4. Modify `set_markdown()` to use the checkbox handler
+5. Modify `as_markdown()` to reconstruct checkbox states
+
+```python
+class AYCommentField(AYTextEdit):
+    """Text field for comment display with markdown support."""
+
+    Variants = QTextEditVariants
+    checklist_changed = Signal()  # NEW: Emitted when checkbox state changes
+
+    def __init__(self, ...):
+        # ... existing code ...
+
+        # NEW: Initialize checkbox handler
+        self._checkbox_handler = CheckboxHandler(self)
+        self._checkbox_handler.checklist_changed.connect(
+            self.checklist_changed.emit
+        )
+
+        # Register custom text object for checkboxes
+        self._register_checkbox_handler()
+```
+
+### 4. Click Detection Strategy
+
+Since checkboxes need to be clickable even in read-only mode, we leverage the existing `mousePressEvent()` override in [`AYCommentField`](client/ayon_ui_qt/components/comment.py:340):
+
+```python
+def mousePressEvent(self, event) -> None:
+    """Handle mouse press events to toggle checkboxes and open links."""
+    cursor = self.cursorForPosition(event.pos())
+    char_format = cursor.charFormat()
+
+    # Check if clicked on a checkbox
+    if char_format.objectType() == CheckboxTextObject.CHECKBOX_FORMAT_TYPE:
+        index = char_format.property(CheckboxTextObject.CHECKBOX_INDEX)
+        self._checkbox_handler.toggle_checkbox(index)
+        self._update_checkbox_display(index)
+        event.accept()
+        return
+
+    # ... existing link handling code ...
+```
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant AYCommentField
+    participant CheckboxHandler
+    participant CheckboxTextObject
+    participant Server
+
+    Note over User,Server: Loading a comment with checkboxes
+    Server->>AYCommentField: set_markdown with - [ ] items
+    AYCommentField->>CheckboxHandler: parse_markdown
+    CheckboxHandler->>CheckboxHandler: Extract checkbox states
+    CheckboxHandler->>AYCommentField: Return checkbox positions
+    AYCommentField->>CheckboxTextObject: Insert custom objects
+    CheckboxTextObject->>User: Render Material icons
+
+    Note over User,Server: User toggles a checkbox
+    User->>AYCommentField: Click on checkbox
+    AYCommentField->>CheckboxHandler: toggle_checkbox index
+    CheckboxHandler->>CheckboxHandler: Update state
+    CheckboxHandler->>AYCommentField: Emit checklist_changed
+    AYCommentField->>Server: Signal handler updates server
+```
+
+## File Changes Summary
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `checkbox_text_object.py` | New | QTextObjectInterface implementation for rendering |
+| `checkbox_handler.py` | New | Checkbox state management and parsing |
+| `comment.py` | Modify | Add signal, integrate handler, click detection |
+| `comment_completion.py` | Modify | Update `parse_markdown_from_web()` to handle checkboxes |
+
+## Implementation Steps
+
+1. **Create CheckboxTextObject class** - Implement the rendering logic for checkbox icons
+2. **Create CheckboxHandler class** - Handle parsing, state management, and markdown export
+3. **Register custom object handler** - Connect `QTextObjectInterface` to `QTextDocument`
+4. **Modify AYCommentField.set_markdown()** - Parse and render checkboxes
+5. **Modify AYCommentField.mousePressEvent()** - Add checkbox click detection
+6. **Modify AYCommentField.as_markdown()** - Export with updated checkbox states
+7. **Add checklist_changed signal** - Wire up the signal emission
+8. **Testing** - Verify roundtrip and visual appearance
+
+## Alternative Approaches Considered
+
+### 1. CSS Styling of Native Markdown Checkboxes
+- **Pros:** Simpler implementation
+- **Cons:** Limited control over appearance, doesn't work in read-only mode
+
+### 2. HTML Rendering with Custom Checkbox Elements
+- **Pros:** Full styling control
+- **Cons:** Requires switching to HTML mode, may break other markdown features
+
+### 3. Overlay Widgets
+- **Pros:** Full widget functionality
+- **Cons:** Complex positioning, synchronization issues with text scrolling
+
+## Questions/Considerations
+
+1. **Checkbox list detection:** Should we only render checkboxes in GitHub-style task lists (`- [ ]`), or also support other formats?
+   - **Recommendation:** Start with GitHub-style only for compatibility
+
+2. **Checkbox indentation:** Should nested checklists be supported?
+   - **Recommendation:** Support flat lists initially, add nesting if needed
+
+3. **Visual feedback:** Should there be hover effects on checkboxes?
+   - **Recommendation:** Yes, change cursor to pointer on hover (already partially implemented for links)
+
+4. **Undo/Redo:** Should checkbox toggles be undoable?
+   - **Recommendation:** Yes, integrate with `QTextDocument`'s undo stack if possible
+
+## Testing Plan
+
+1. **Unit tests for CheckboxHandler:**
+   - Parse various markdown formats
+   - Toggle state correctly
+   - Export markdown correctly
+
+2. **Visual tests:**
+   - Checkboxes render with correct icons
+   - Icon colors are correct (white unchecked, green checked)
+   - Icon size scales with font
+
+3. **Interaction tests:**
+   - Click toggles checkbox in editable mode
+   - Click toggles checkbox in read-only mode
+   - Signal is emitted on toggle
+
+4. **Roundtrip tests:**
+   - Markdown -> display -> markdown preserves checkbox states
+   - Mixed content (text + checkboxes + links) works correctly


### PR DESCRIPTION
## Changelog Description
Add interactive checklist editing to AYTextEditor/AYTextBox/AYCommentField.
New CheckboxHandler will:
  - Parse markdown to extract checkbox items
  - Register custom text objects for checkbox rendering
  - Track checkbox state and positions
  - Convert back to markdown format

## Additional review information
That was not straightforward. QTextDocument and the whole system can be tricky.

## Testing notes:
1. start with this step
2. follow this step
