### PR TITLE
Make the image cache process-safe

### DIFF
--- a/client/ayon_ui_qt/image_cache.py
+++ b/client/ayon_ui_qt/image_cache.py
@@ -285,7 +285,13 @@ class ImageCache:
             ).fetchone()
             if row is None:
                 return False
-            return Path(row[0]).exists()
+            cached_path = Path(row[0])
+            if cached_path.exists():
+                return True
+            # File gone — purge the stale row to keep DB in sync with disk
+            self._db.execute("DELETE FROM cache WHERE key = ?", (key,))
+            self._db.commit()
+            return False
 
     def get_path(self, key: str) -> str | None:
         """Return the cached file path for *key* if it exists, else None.

--- a/client/ayon_ui_qt/image_cache.py
+++ b/client/ayon_ui_qt/image_cache.py
@@ -312,6 +312,12 @@ class ImageCache:
                 return None
             cached_path = Path(row[0])
             if not cached_path.exists():
+                # Remove stale DB entry when the underlying file is missing
+                self._db.execute(
+                    "DELETE FROM cache WHERE key = ?",
+                    (key,),
+                )
+                self._db.commit()
                 return None
             self._db.execute(
                 "UPDATE cache "

--- a/client/ayon_ui_qt/image_cache.py
+++ b/client/ayon_ui_qt/image_cache.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import atexit
 import hashlib
-import json
 import logging
+import os
+import sqlite3
+import tempfile
 import threading
 import time
-import tempfile
-import os
 from pathlib import Path
 from typing import Callable
 
@@ -17,24 +17,39 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS cache (
+    key           TEXT PRIMARY KEY,
+    file_path     TEXT NOT NULL,
+    size_bytes    INTEGER NOT NULL,
+    access_count  INTEGER DEFAULT 1,
+    last_accessed REAL NOT NULL
+);
+"""
+
+_CREATE_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_last_accessed ON cache(last_accessed);
+"""
+
 
 class ImageCache:
-    """Thread-safe LRU cache singleton for storing and retrieving images.
+    """Process- and thread-safe LRU image cache backed by SQLite.
 
-    This cache manages image files on disk with automatic eviction based on
-    size limits. It maintains metadata in JSON format and ensures thread-safe
-    access through locking mechanisms.
+    Stores image files on disk and tracks metadata in a SQLite database.
+    Eviction is based on least-recently-used (LRU) access time. WAL journal
+    mode and busy_timeout allow multiple processes to share the same cache
+    directory safely.
 
     Environment variables:
-        AYON_IMG_CACHE_DIR: Override directory in which the AYON_IMG_CACHE dir
-                            will be created, otherwise use a stable tmp
-                            location.
+        AYON_IMG_CACHE_DIR: Parent directory for the AYON_IMG_CACHE folder.
+                            Defaults to the system temp directory.
         AYON_IMG_CACHE_SIZE: Override default cache size in MB.
-        AYON_IMG_CACHE_CLEAR_ON_STARTUP: Always clear cache on startup.
+        AYON_IMG_CACHE_CLEAR_ON_STARTUP: Clear all cache files on startup.
 
     Attributes:
         cache_path (Path): Directory where cached files are stored.
         max_size_in_MB (int): Maximum cache size in megabytes.
+        max_size_bytes (int): Maximum cache size in bytes.
     """
 
     _instance: ImageCache | None = None
@@ -42,16 +57,18 @@ class ImageCache:
 
     @classmethod
     def get_instance(
-        cls, cache_path: str | Path | None = None, max_size_in_MB: int = 500
+        cls,
+        cache_path: str | Path | None = None,
+        max_size_in_MB: int = 500,
     ) -> ImageCache:
-        """Get or create the singleton cache instance.
+        """Return the singleton cache instance, creating it if needed.
 
         Args:
             cache_path: Directory path for storing cached files.
             max_size_in_MB: Maximum cache size in megabytes.
 
         Returns:
-            ImageCache: The singleton cache instance.
+            The singleton ImageCache instance.
 
         Raises:
             ValueError: If max_size_in_MB is not positive.
@@ -64,13 +81,15 @@ class ImageCache:
                 instance = object.__new__(cls)
                 instance._initialize(cache_path, max_size_in_MB)
                 cls._instance = instance
-                atexit.register(cls._instance._save_metadata)
             return cls._instance
+
+    # ------------------------------------------------------------------
+    # Initialisation
+    # ------------------------------------------------------------------
 
     def _get_tmp_dir(self) -> Path:
         tmp = Path(os.environ.get("AYON_IMG_CACHE_DIR", tempfile.gettempdir()))
         tmp = tmp / "AYON_IMG_CACHE"
-        # make tmp writable and readable to the user only
         tmp.mkdir(parents=True, exist_ok=True)
         if os.name != "nt":
             os.chmod(tmp, 0o700)
@@ -78,118 +97,125 @@ class ImageCache:
         return tmp
 
     def _initialize(
-        self, cache_path: str | Path | None, max_size_in_MB: int
+        self,
+        cache_path: str | Path | None,
+        max_size_in_MB: int,
     ) -> None:
-        """Initialize the cache instance.
+        """Initialise the cache instance.
 
         Args:
             cache_path: Directory path for storing cached files.
             max_size_in_MB: Maximum cache size in megabytes.
         """
-        self.max_size_in_MB = os.environ.get(
-            "AYON_IMG_CACHE_SIZE", max_size_in_MB
-        )
-        self.max_size_bytes = max_size_in_MB * 1024 * 1024
+        raw_size = os.environ.get("AYON_IMG_CACHE_SIZE", max_size_in_MB)
+        self.max_size_in_MB = int(raw_size)
+        self.max_size_bytes = self.max_size_in_MB * 1024 * 1024
+
         self.cache_path = (
             Path(cache_path) if cache_path else self._get_tmp_dir()
         )
-        self._metadata_file = self.cache_path / "cache_metadata.json"
-        self._metadata: dict[str, dict] = {}
-        self._access_lock = threading.Lock()
-
-        # Create cache directory if it doesn't exist
         self.cache_path.mkdir(parents=True, exist_ok=True)
 
+        self._db_path = self.cache_path / "cache_metadata.db"
+        self._db = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        self._db.execute("PRAGMA busy_timeout=10000")
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute(_CREATE_TABLE_SQL)
+        self._db.execute(_CREATE_INDEX_SQL)
+        self._db.commit()
+
+        self._access_lock = threading.Lock()
+
         if "AYON_IMG_CACHE_CLEAR_ON_STARTUP" in os.environ:
-            i = 0
-            for i, f in enumerate(os.scandir(self.cache_path)):
-                if f.is_file():
-                    os.remove(self.cache_path / f.path)
-            logger.info(f"AYON image cache: cleared ({i} files removed)")
+            self._clear_all_files()
 
-        # Load existing metadata and validate files
-        self._load_metadata()
         self._validate_cache_files()
+        self._cleanup_legacy_files()
 
-    def _load_metadata(self) -> None:
-        """Load cache metadata from JSON file.
+        atexit.register(self._db.close)
 
-        If the metadata file doesn't exist, initialize empty metadata.
-        """
-        if self._metadata_file.exists():
-            try:
-                with open(self._metadata_file, "r") as f:
-                    self._metadata = json.load(f)
-                logger.debug(
-                    f"Loaded cache metadata with {len(self._metadata)} entries"
-                )
-            except (json.JSONDecodeError, IOError) as e:
-                logger.warning(
-                    f"Failed to load metadata: {e}. Starting fresh."
-                )
-                self._metadata = {}
-        else:
-            self._metadata = {}
+    def _clear_all_files(self) -> None:
+        """Delete every file in the cache directory and reset the DB."""
+        count = 0
+        for entry in os.scandir(self.cache_path):
+            if entry.is_file() and entry.name != self._db_path.name:
+                try:
+                    os.remove(entry.path)
+                    count += 1
+                except OSError as exc:
+                    logger.warning(f"Could not remove {entry.path}: {exc}")
+        self._db.execute("DELETE FROM cache")
+        self._db.commit()
+        logger.info(f"AYON image cache: cleared ({count} files removed)")
 
-    def _validate_cache_files(self) -> None:
-        """Remove metadata entries for files that no longer exist.
+    def _cleanup_legacy_files(self) -> None:
+        """Remove legacy JSON metadata files left from the previous version."""
+        for name in ("cache_metadata.json", "cache_metadata.json.lock"):
+            legacy = self.cache_path / name
+            if legacy.exists():
+                try:
+                    legacy.unlink()
+                    logger.debug(f"Removed legacy cache file: {legacy}")
+                except OSError as exc:
+                    logger.warning(
+                        f"Could not remove legacy file {legacy}: {exc}"
+                    )
 
-        This ensures cache integrity on startup.
-        """
-        invalid_keys = []
-        for key, entry in self._metadata.items():
-            file_path = Path(entry.get("file_path", ""))
-            if not file_path.exists():
-                invalid_keys.append(key)
-                logger.warning(
-                    f"Cache file missing for key '{key}': {file_path}"
-                )
-
-        for key in invalid_keys:
-            del self._metadata[key]
-
-        if invalid_keys:
-            logger.debug(f"Removed {len(invalid_keys)} invalid cache entries")
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def get(self, key: str, file_closure: Callable) -> str:
-        """Get a cached file or load it using the provided file_closure.
+        """Return the cached file path for *key*, caching it if necessary.
+
+        If *key* is not in the cache (or its file was deleted), *file_closure*
+        is called to obtain the source file, which is then copied atomically
+        into the cache directory.
 
         Args:
             key: Unique identifier for the cached file.
-            file_closure: Callable that returns the path to the file to cache.
-                          Called only if the key is not in the cache.
+            file_closure: Callable returning the path to the source file.
+                          Called only on a cache miss.
 
         Returns:
-            str: Path to the cached file.
+            Absolute path to the cached file as a string.
 
         Raises:
-            ValueError: If key is empty or file_closure returns invalid path.
-            IOError: If file operations fail.
+            ValueError: If *key* is empty or *file_closure* returns a path
+                        that does not exist.
+            IOError: If the file cannot be copied into the cache.
         """
         if not key:
             raise ValueError("Cache key cannot be empty")
 
         with self._access_lock:
-            # Check if key exists in cache
-            if key in self._metadata:
-                entry = self._metadata[key]
-                cached_path = Path(entry["file_path"])
+            row = self._db.execute(
+                "SELECT file_path FROM cache WHERE key = ?", (key,)
+            ).fetchone()
 
-                # Verify file still exists
+            if row is not None:
+                cached_path = Path(row[0])
                 if cached_path.exists():
-                    # Update access info
-                    entry["access_count"] = entry.get("access_count", 0) + 1
-                    entry["last_accessed"] = time.time()
+                    self._db.execute(
+                        "UPDATE cache "
+                        "SET access_count = access_count + 1,"
+                        "    last_accessed = ? "
+                        "WHERE key = ?",
+                        (time.time(), key),
+                    )
+                    self._db.commit()
                     logger.debug(f"Cache hit for key '{key}'")
                     return str(cached_path)
-                else:
-                    # File was deleted, remove from cache
-                    logger.debug(
-                        f"Cached file missing for key '{key}': {cached_path}"
-                    )
-                    del self._metadata[key]
 
-            # Cache miss: call file_closure to get file
+                # File gone — purge the stale row
+                logger.debug(
+                    f"Cached file missing for key '{key}': {cached_path}"
+                )
+                self._db.execute("DELETE FROM cache WHERE key = ?", (key,))
+                self._db.commit()
+
+            # Cache miss — call the closure inside the lock to prevent
+            # duplicate work from concurrent threads.
             logger.debug(f"Cache miss for key '{key}', calling file_closure")
             source_path = Path(file_closure())
 
@@ -198,137 +224,183 @@ class ImageCache:
                     f"Loader returned non-existent file: {source_path}"
                 )
 
-            # Generate cache filename from key hash
             cache_filename = self._generate_cache_filename(key, source_path)
             cached_path = self.cache_path / cache_filename
 
-            # Move file to cache
-            try:
-                # Copy file to cache (preserves original)
-                with open(source_path, "rb") as src:
-                    with open(cached_path, "wb") as dst:
-                        dst.write(src.read())
-            except IOError as e:
-                raise IOError(f"Failed to cache file: {e}") from e
+            self._atomic_copy(source_path, cached_path)
 
-            # Get file size
             file_size = cached_path.stat().st_size
+            self._db.execute(
+                "INSERT OR REPLACE INTO cache "
+                "(key, file_path, size_bytes, access_count, last_accessed) "
+                "VALUES (?, ?, ?, 1, ?)",
+                (key, str(cached_path), file_size, time.time()),
+            )
+            self._db.commit()
 
-            # Add entry to metadata
-            self._metadata[key] = {
-                "file_path": str(cached_path),
-                "size_bytes": file_size,
-                "access_count": 1,
-                "last_accessed": time.time(),
-            }
-
-            # Check cache size and evict if necessary
             self._evict_if_needed()
 
             logger.debug(f"Cached file for key '{key}': {cached_path}")
             return str(cached_path)
 
     def has(self, key: str) -> bool:
-        """Check if a key exists in cache without loading."""
+        """Return True if *key* is cached and its file exists on disk.
+
+        Args:
+            key: Cache key to check.
+
+        Returns:
+            True if the key is present and the file exists, else False.
+        """
         with self._access_lock:
-            if key in self._metadata:
-                cached = Path(self._metadata[key]["file_path"])
-                return cached.exists()
-            return False
+            row = self._db.execute(
+                "SELECT file_path FROM cache WHERE key = ?", (key,)
+            ).fetchone()
+            if row is None:
+                return False
+            return Path(row[0]).exists()
 
     def get_path(self, key: str) -> str | None:
-        """Return cached path if it exists, else None."""
+        """Return the cached file path for *key* if it exists, else None.
+
+        Updates access metadata when the entry is found.
+
+        Args:
+            key: Cache key to look up.
+
+        Returns:
+            Absolute path string to the cached file, or None.
+        """
         with self._access_lock:
-            if key in self._metadata:
-                cached = Path(self._metadata[key]["file_path"])
-                if cached.exists():
-                    entry = self._metadata[key]
-                    entry["access_count"] += 1
-                    entry["last_accessed"] = time.time()
-                    return str(cached)
-            return None
+            row = self._db.execute(
+                "SELECT file_path FROM cache WHERE key = ?", (key,)
+            ).fetchone()
+            if row is None:
+                return None
+            cached_path = Path(row[0])
+            if not cached_path.exists():
+                return None
+            self._db.execute(
+                "UPDATE cache "
+                "SET access_count = access_count + 1,"
+                "    last_accessed = ? "
+                "WHERE key = ?",
+                (time.time(), key),
+            )
+            self._db.commit()
+            return str(cached_path)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _atomic_copy(self, src: Path, dst: Path) -> None:
+        """Copy *src* to *dst* atomically using a temp file + os.replace().
+
+        The temporary file is created in the same directory as *dst* so that
+        ``os.replace`` is an atomic rename on the same filesystem.
+
+        Args:
+            src: Source file path.
+            dst: Destination file path.
+
+        Raises:
+            IOError: If the copy or rename fails.
+        """
+        fd, tmp_path = tempfile.mkstemp(dir=self.cache_path)
+        try:
+            try:
+                with os.fdopen(fd, "wb") as tmp_fh:
+                    with open(src, "rb") as src_fh:
+                        tmp_fh.write(src_fh.read())
+            except Exception:
+                os.close(fd)
+                raise
+            os.replace(tmp_path, dst)
+        except IOError as exc:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise IOError(f"Failed to cache file: {exc}") from exc
 
     def _generate_cache_filename(self, key: str, source_path: Path) -> str:
-        """Generate a cache filename from the key hash.
+        """Build a cache filename from a SHA-256 hash of *key*.
 
         Args:
             key: The cache key.
-            source_path: The original file path (to get extension).
+            source_path: The original file (used only to preserve extension).
 
         Returns:
-            str: The cache filename with preserved extension.
+            Filename string with the original extension.
         """
         key_hash = hashlib.sha256(key.encode()).hexdigest()
         extension = source_path.suffix
         return f"{key_hash}{extension}"
 
     def _evict_if_needed(self) -> None:
-        """Evict least recently used files if cache exceeds max size.
-
-        Continues eviction until cache size is at 90% of max_size.
-        """
+        """Evict LRU entries until cache size is at 90 % of the limit."""
         current_size = self._get_cache_size()
 
-        if current_size > self.max_size_bytes:
-            target_size = int(self.max_size_bytes * 0.9)
-            logger.info(
-                f"Cache size ({current_size} bytes) exceeds limit "
-                f"({self.max_size_bytes} bytes). Evicting to {target_size} "
-                "bytes"
+        if current_size <= self.max_size_bytes:
+            return
+
+        target_size = int(self.max_size_bytes * 0.9)
+        logger.info(
+            f"Cache size ({current_size} bytes) exceeds limit "
+            f"({self.max_size_bytes} bytes). Evicting to {target_size} bytes"
+        )
+
+        rows = self._db.execute(
+            "SELECT key, file_path, size_bytes FROM cache ORDER BY last_accessed ASC"
+        ).fetchall()
+
+        keys_to_delete: list[str] = []
+        for key, file_path_str, size_bytes in rows:
+            if current_size <= target_size:
+                break
+            file_path = Path(file_path_str)
+            try:
+                if file_path.exists():
+                    file_path.unlink()
+                current_size -= size_bytes
+                keys_to_delete.append(key)
+                logger.debug(f"Evicted cache entry for key '{key}'")
+            except OSError as exc:
+                logger.warning(f"Failed to delete cache file: {exc}")
+
+        if keys_to_delete:
+            placeholders = ",".join("?" * len(keys_to_delete))
+            self._db.execute(
+                f"DELETE FROM cache WHERE key IN ({placeholders})",
+                keys_to_delete,
             )
-
-            # Sort by last_accessed (least recently used first)
-            sorted_entries = sorted(
-                self._metadata.items(),
-                key=lambda x: x[1].get("last_accessed", 0),
-            )
-
-            for key, entry in sorted_entries:
-                if current_size <= target_size:
-                    break
-
-                file_path = Path(entry["file_path"])
-                file_size = entry.get("size_bytes", 0)
-
-                try:
-                    if file_path.exists():
-                        file_path.unlink()
-                        current_size -= file_size
-                        logger.debug(f"Evicted cache entry for key '{key}'")
-                except OSError as e:
-                    logger.warning(f"Failed to delete cache file: {e}")
-
-                del self._metadata[key]
+            self._db.commit()
 
     def _get_cache_size(self) -> int:
-        """Calculate total cache size in bytes.
+        """Return the total size of all cached entries in bytes.
 
         Returns:
-            int: Total size of all cached files in bytes.
+            Total bytes recorded in the database.
         """
-        total_size = 0
-        for entry in self._metadata.values():
-            file_path = Path(entry.get("file_path", ""))
-            if file_path.exists():
-                total_size += file_path.stat().st_size
-            else:
-                # Update metadata if file is missing
-                total_size += entry.get("size_bytes", 0)
-        return total_size
+        row = self._db.execute(
+            "SELECT COALESCE(SUM(size_bytes), 0) FROM cache"
+        ).fetchone()
+        return int(row[0])
 
-    def _save_metadata(self) -> None:
-        """Save cache metadata to JSON file."""
-        try:
-            with self._access_lock:
-                with open(self._metadata_file, "w") as fw:
-                    json.dump(self._metadata, fw, indent=4)
-            logger.debug("Cache metadata saved")
-        except IOError as e:
-            logger.error(f"Failed to save cache metadata: {e}")
+    def _validate_cache_files(self) -> None:
+        """Remove DB entries whose files no longer exist on disk."""
+        rows = self._db.execute("SELECT key, file_path FROM cache").fetchall()
 
-    def __del__(self) -> None:
-        """Save metadata when cache is destroyed."""
-        try:
-            self._save_metadata()
-        except Exception as e:
-            logger.error(f"Failed to save cache metadata: {e}")
+        invalid_keys = [key for key, fp in rows if not Path(fp).exists()]
+
+        if not invalid_keys:
+            return
+
+        placeholders = ",".join("?" * len(invalid_keys))
+        self._db.execute(
+            f"DELETE FROM cache WHERE key IN ({placeholders})",
+            invalid_keys,
+        )
+        self._db.commit()
+        logger.debug(f"Removed {len(invalid_keys)} invalid cache entries")

--- a/client/ayon_ui_qt/image_cache.py
+++ b/client/ayon_ui_qt/image_cache.py
@@ -4,17 +4,15 @@ import atexit
 import hashlib
 import logging
 import os
+import shutil
 import sqlite3
 import tempfile
 import threading
 import time
+import weakref
 from pathlib import Path
 from typing import Callable
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="[%(levelname)s]:   %(funcName)16s:  %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 _CREATE_TABLE_SQL = """
@@ -32,13 +30,47 @@ CREATE INDEX IF NOT EXISTS idx_last_accessed ON cache(last_accessed);
 """
 
 
+def _parse_positive_int(value: int | str, label: str) -> int:
+    """Parse and validate a positive integer value.
+
+    Args:
+        value: The value to parse.
+        label: Human-readable name for error messages.
+
+    Returns:
+        The parsed positive integer.
+
+    Raises:
+        ValueError: If *value* cannot be parsed or is not positive.
+    """
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{label} must be a positive integer, got {value!r}"
+        ) from exc
+    if result <= 0:
+        raise ValueError(f"{label} must be a positive integer, got {value!r}")
+    return result
+
+
 class ImageCache:
     """Process- and thread-safe LRU image cache backed by SQLite.
 
     Stores image files on disk and tracks metadata in a SQLite database.
-    Eviction is based on least-recently-used (LRU) access time. WAL journal
-    mode and busy_timeout allow multiple processes to share the same cache
-    directory safely.
+    Eviction is based on least-recently-used (LRU) access time.
+
+    Concurrency model:
+        - Each thread gets its own ``sqlite3.Connection`` via
+          ``threading.local()``.  SQLite WAL journal mode allows multiple
+          readers to proceed concurrently across both threads and OS processes;
+          writers are serialised by SQLite's internal file-level locking, with
+          a 10-second busy-timeout handling contention.
+        - Cache-miss work (calling *file_closure* and copying the file) is
+          serialised **per cache key** via a per-key ``threading.Lock``.
+          Threads requesting different keys proceed fully in parallel; threads
+          requesting the same key during a miss wait for exactly one download
+          to complete and then read the already-populated entry.
 
     Environment variables:
         AYON_IMG_CACHE_DIR: Parent directory for the AYON_IMG_CACHE folder.
@@ -63,6 +95,10 @@ class ImageCache:
     ) -> ImageCache:
         """Return the singleton cache instance, creating it if needed.
 
+        NOTE: `cache_path` and `max_size_in_MB` are only used on the first
+              call. Subsequent calls return the same instance regardless of
+              the arguments.
+
         Args:
             cache_path: Directory path for storing cached files.
             max_size_in_MB: Maximum cache size in megabytes.
@@ -73,19 +109,39 @@ class ImageCache:
         Raises:
             ValueError: If max_size_in_MB is not positive.
         """
-        if max_size_in_MB <= 0:
-            raise ValueError("max_size_in_MB must be positive")
-
         with cls._lock:
-            if cls._instance is None:
-                instance = object.__new__(cls)
-                instance._initialize(cache_path, max_size_in_MB)
-                cls._instance = instance
+            if cls._instance is not None:
+                return cls._instance
+            if max_size_in_MB <= 0:
+                raise ValueError("max_size_in_MB must be positive")
+            instance = object.__new__(cls)
+            instance._initialize(cache_path, max_size_in_MB)
+            cls._instance = instance
             return cls._instance
 
     # ------------------------------------------------------------------
     # Initialisation
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_sqlite_version() -> None:
+        """Raise RuntimeError if the runtime SQLite is too old.
+
+        WAL journal mode requires SQLite ≥ 3.7.0 (released 2010).  Any
+        reasonably modern Python 3 installation satisfies this requirement,
+        but distributions that link CPython against a very old system SQLite
+        could fail at the PRAGMA call without a clear error message.  This
+        check surfaces the problem at initialisation time.
+
+        Raises:
+            RuntimeError: If the runtime SQLite version is below 3.7.0.
+        """
+        min_version = (3, 7, 0)
+        if sqlite3.sqlite_version_info < min_version:
+            raise RuntimeError(
+                f"ImageCache requires SQLite >= {'.'.join(map(str, min_version))};"
+                f" found {sqlite3.sqlite_version}"
+            )
 
     def _get_tmp_dir(self) -> Path:
         tmp = Path(os.environ.get("AYON_IMG_CACHE_DIR", tempfile.gettempdir()))
@@ -107,35 +163,17 @@ class ImageCache:
             cache_path: Directory path for storing cached files.
             max_size_in_MB: Maximum cache size in megabytes.
         """
-        raw_size_env = os.environ.get("AYON_IMG_CACHE_SIZE")
-        if raw_size_env is not None:
-            try:
-                parsed_size = int(raw_size_env)
-            except (TypeError, ValueError) as exc:
-                raise ValueError(
-                    f"Environment variable AYON_IMG_CACHE_SIZE must be an integer "
-                    f"number of megabytes, got {raw_size_env!r}"
-                ) from exc
-            if parsed_size <= 0:
-                raise ValueError(
-                    f"Environment variable AYON_IMG_CACHE_SIZE must be a positive "
-                    f"integer number of megabytes, got {raw_size_env!r}"
-                )
-            self.max_size_in_MB = parsed_size
+        self._check_sqlite_version()
+
+        raw = os.environ.get("AYON_IMG_CACHE_SIZE")
+        if raw is not None:
+            self.max_size_in_MB = _parse_positive_int(
+                raw, "AYON_IMG_CACHE_SIZE"
+            )
         else:
-            try:
-                parsed_size = int(max_size_in_MB)
-            except (TypeError, ValueError) as exc:
-                raise ValueError(
-                    f"max_size_in_MB must be an integer number of megabytes, "
-                    f"got {max_size_in_MB!r}"
-                ) from exc
-            if parsed_size <= 0:
-                raise ValueError(
-                    f"max_size_in_MB must be a positive integer number of "
-                    f"megabytes, got {max_size_in_MB!r}"
-                )
-            self.max_size_in_MB = parsed_size
+            self.max_size_in_MB = _parse_positive_int(
+                max_size_in_MB, "max_size_in_MB"
+            )
         self.max_size_bytes = self.max_size_in_MB * 1024 * 1024
 
         self.cache_path = (
@@ -144,14 +182,30 @@ class ImageCache:
         self.cache_path.mkdir(parents=True, exist_ok=True)
 
         self._db_path = self.cache_path / "cache_metadata.db"
-        self._db = sqlite3.connect(str(self._db_path), check_same_thread=False)
-        self._db.execute("PRAGMA busy_timeout=10000")
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute(_CREATE_TABLE_SQL)
-        self._db.execute(_CREATE_INDEX_SQL)
-        self._db.commit()
 
-        self._access_lock = threading.Lock()
+        # Per-thread connection storage.
+        self._local = threading.local()
+
+        # Guards both _key_locks and _all_connections.
+        self._meta_lock = threading.Lock()
+
+        # Per-key locks that serialise cache-miss work for the same key.
+        # WeakValueDictionary ensures locks are garbage-collected once no
+        # thread holds a reference, preventing unbounded growth.
+        self._key_locks: weakref.WeakValueDictionary[str, threading.Lock] = (
+            weakref.WeakValueDictionary()
+        )
+
+        # Registry of every connection ever opened so they can all be
+        # closed at process exit.
+        self._all_connections: list[sqlite3.Connection] = []
+
+        # Initialise the schema using the calling thread's connection.
+        setup_conn = self._get_conn()
+        self._set_wal_mode(setup_conn)
+        setup_conn.execute(_CREATE_TABLE_SQL)
+        setup_conn.execute(_CREATE_INDEX_SQL)
+        setup_conn.commit()
 
         if "AYON_IMG_CACHE_CLEAR_ON_STARTUP" in os.environ:
             self._clear_all_files()
@@ -159,10 +213,11 @@ class ImageCache:
         self._validate_cache_files()
         self._cleanup_legacy_files()
 
-        atexit.register(self._db.close)
+        atexit.register(self._close_all_connections)
 
     def _clear_all_files(self) -> None:
         """Delete every file in the cache directory and reset the DB."""
+        conn = self._get_conn()
         count = 0
         for entry in os.scandir(self.cache_path):
             if entry.is_file() and entry.name != self._db_path.name:
@@ -171,8 +226,8 @@ class ImageCache:
                     count += 1
                 except OSError as exc:
                     logger.warning(f"Could not remove {entry.path}: {exc}")
-        self._db.execute("DELETE FROM cache")
-        self._db.commit()
+        conn.execute("DELETE FROM cache")
+        conn.commit()
         logger.info(f"AYON image cache: cleared ({count} files removed)")
 
     def _cleanup_legacy_files(self) -> None:
@@ -188,6 +243,154 @@ class ImageCache:
                         f"Could not remove legacy file {legacy}: {exc}"
                     )
 
+    def _set_wal_mode(
+        self,
+        conn: sqlite3.Connection,
+        retries: int = 5,
+        base_delay: float = 0.1,
+    ) -> None:
+        """Switch the database to WAL journal mode with retries.
+
+        ``PRAGMA journal_mode=WAL`` requires an exclusive lock on the
+        database file.  Under heavy concurrent process startup the lock
+        may not be available even though ``busy_timeout`` is set, so we
+        retry with linear back-off.
+
+        Args:
+            conn: The connection to use for setting WAL mode.
+            retries: Maximum number of attempts.
+            base_delay: Seconds to wait between attempts (multiplied
+                by the attempt number).
+        """
+        for attempt in range(retries):
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+                return
+            except sqlite3.OperationalError:
+                if attempt == retries - 1:
+                    raise
+                time.sleep(base_delay * (attempt + 1))
+
+    # ------------------------------------------------------------------
+    # Connection management
+    # ------------------------------------------------------------------
+
+    def _open_connection(self) -> sqlite3.Connection:
+        """Open and configure a new SQLite connection.
+
+        WAL journal mode is **not** set here; it is a one-time,
+        exclusive-lock operation performed during initialisation via
+        ``_set_wal_mode``.  Once set, WAL mode is stored in the database
+        file header and all subsequent connections inherit it automatically.
+
+        Returns:
+            A new ``sqlite3.Connection`` configured with busy_timeout.
+        """
+        return sqlite3.connect(str(self._db_path), timeout=10)
+
+    def _get_conn(self) -> sqlite3.Connection:
+        """Return the per-thread SQLite connection, creating it if needed.
+
+        Each thread gets its own connection, which avoids the need for an
+        application-level lock on reads.  New connections are registered in
+        ``_all_connections`` so they can be closed at process exit.
+
+        Returns:
+            The ``sqlite3.Connection`` for the calling thread.
+        """
+        conn = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = self._open_connection()
+            self._local.conn = conn
+            with self._meta_lock:
+                self._all_connections.append(conn)
+        return conn
+
+    def _close_all_connections(self) -> None:
+        """Close every per-thread connection opened by this instance.
+
+        Registered with ``atexit`` during initialisation.
+        """
+        with self._meta_lock:
+            for conn in self._all_connections:
+                try:
+                    conn.close()
+                except Exception:
+                    logger.debug(
+                        "Exception while closing cache DB connection",
+                        exc_info=True,
+                    )
+            self._all_connections.clear()
+
+    # ------------------------------------------------------------------
+    # Per-key locking
+    # ------------------------------------------------------------------
+
+    def _get_key_lock(self, key: str) -> threading.Lock:
+        """Return the per-key lock for *key*, creating it if needed.
+
+        Args:
+            key: The cache key.
+
+        Returns:
+            A ``threading.Lock`` dedicated to *key*.
+        """
+        with self._meta_lock:
+            lock = self._key_locks.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                self._key_locks[key] = lock
+            return lock
+
+    # ------------------------------------------------------------------
+    # Internal DB helpers
+    # ------------------------------------------------------------------
+
+    def _lookup(self, key: str) -> Path | None:
+        """Return the cached ``Path`` for *key* without updating metadata.
+
+        Purges the DB row and returns ``None`` if the file is missing on disk.
+
+        Args:
+            key: The cache key to look up.
+
+        Returns:
+            Absolute ``Path`` to the cached file, or ``None`` on a miss.
+        """
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT file_path FROM cache WHERE key = ?", (key,)
+        ).fetchone()
+        if row is None:
+            return None
+        cached_path = Path(row[0])
+        if cached_path.exists():
+            return cached_path
+        logger.debug(f"Cached file missing for key '{key}': purging row")
+        conn.execute("DELETE FROM cache WHERE key = ?", (key,))
+        conn.commit()
+        return None
+
+    def _touch(self, key: str) -> None:
+        """Increment the access counter and refresh last_accessed for *key*.
+
+        This is a best-effort metadata update for LRU ordering.  If the row
+        has been removed between a preceding ``_lookup`` and this call (e.g.
+        by a concurrent eviction), the ``UPDATE`` matches zero rows and is
+        silently discarded — LRU accuracy is not required to be exact.
+
+        Args:
+            key: The cache key to update.
+        """
+        conn = self._get_conn()
+        conn.execute(
+            "UPDATE cache "
+            "SET access_count = access_count + 1, last_accessed = ? "
+            "WHERE key = ?",
+            (time.time(), key),
+        )
+        conn.commit()
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -195,9 +398,19 @@ class ImageCache:
     def get(self, key: str, file_closure: Callable) -> str:
         """Return the cached file path for *key*, caching it if necessary.
 
-        If *key* is not in the cache (or its file was deleted), *file_closure*
-        is called to obtain the source file, which is then copied atomically
-        into the cache directory.
+        Cache hits are served via a fast path that requires no application-
+        level locking; SQLite WAL mode allows concurrent reads across threads
+        and processes.
+
+        On a cache miss, a per-key lock is acquired so that only one thread
+        calls *file_closure* for a given key at a time.  After acquiring the
+        lock the database is re-checked: if another thread already populated
+        the entry the result is returned immediately without calling the
+        closure again.
+
+        *file_closure* is called **outside** any database transaction, so a
+        slow I/O operation (e.g. a network download) does not block threads
+        that are requesting different keys.
 
         Args:
             key: Unique identifier for the cached file.
@@ -215,34 +428,33 @@ class ImageCache:
         if not key:
             raise ValueError("Cache key cannot be empty")
 
-        with self._access_lock:
-            row = self._db.execute(
-                "SELECT file_path FROM cache WHERE key = ?", (key,)
-            ).fetchone()
+        # ------------------------------------------------------------------
+        # ------------------------------------------------------------------
+        # Fast path: pure SELECT — concurrent reads across threads/processes
+        # proceed without blocking each other in WAL mode.  _touch is a
+        # separate best-effort write; LRU accuracy does not need to be exact.
+        # ------------------------------------------------------------------
+        cached_path = self._lookup(key)
+        if cached_path is not None:
+            self._touch(key)
+            logger.debug(f"Cache hit for key '{key}'")
+            return str(cached_path)
 
-            if row is not None:
-                cached_path = Path(row[0])
-                if cached_path.exists():
-                    self._db.execute(
-                        "UPDATE cache "
-                        "SET access_count = access_count + 1,"
-                        "    last_accessed = ? "
-                        "WHERE key = ?",
-                        (time.time(), key),
-                    )
-                    self._db.commit()
-                    logger.debug(f"Cache hit for key '{key}'")
-                    return str(cached_path)
+        # ------------------------------------------------------------------
+        # Slow path: acquire the per-key lock, then double-check.
+        # Only threads requesting the same key are serialised here; threads
+        # requesting different keys proceed fully in parallel.
+        # ------------------------------------------------------------------
+        with self._get_key_lock(key):
+            # Double-check: another thread may have populated the entry
+            # while we were waiting for the key lock.
+            cached_path = self._lookup(key)
+            if cached_path is not None:
+                self._touch(key)
+                logger.debug(f"Cache hit for key '{key}' (after key lock)")
+                return str(cached_path)
 
-                # File gone — purge the stale row
-                logger.debug(
-                    f"Cached file missing for key '{key}': {cached_path}"
-                )
-                self._db.execute("DELETE FROM cache WHERE key = ?", (key,))
-                self._db.commit()
-
-            # Cache miss — call the closure inside the lock to prevent
-            # duplicate work from concurrent threads.
+            # True miss: call the closure outside any database transaction.
             logger.debug(f"Cache miss for key '{key}', calling file_closure")
             source_path = Path(file_closure())
 
@@ -256,19 +468,22 @@ class ImageCache:
 
             self._atomic_copy(source_path, cached_path)
 
+            conn = self._get_conn()
             file_size = cached_path.stat().st_size
-            self._db.execute(
+            conn.execute(
                 "INSERT OR REPLACE INTO cache "
                 "(key, file_path, size_bytes, access_count, last_accessed) "
                 "VALUES (?, ?, ?, 1, ?)",
                 (key, str(cached_path), file_size, time.time()),
             )
-            self._db.commit()
+            conn.commit()
 
-            self._evict_if_needed()
+        # Eviction runs outside the per-key lock: it can be slow (file I/O +
+        # bulk DB DELETE) and must not block other threads querying this key.
+        self._evict_if_needed()
 
-            logger.debug(f"Cached file for key '{key}': {cached_path}")
-            return str(cached_path)
+        logger.debug(f"Cached file for key '{key}': {cached_path}")
+        return str(cached_path)
 
     def has(self, key: str) -> bool:
         """Return True if *key* is cached and its file exists on disk.
@@ -279,19 +494,7 @@ class ImageCache:
         Returns:
             True if the key is present and the file exists, else False.
         """
-        with self._access_lock:
-            row = self._db.execute(
-                "SELECT file_path FROM cache WHERE key = ?", (key,)
-            ).fetchone()
-            if row is None:
-                return False
-            cached_path = Path(row[0])
-            if cached_path.exists():
-                return True
-            # File gone — purge the stale row to keep DB in sync with disk
-            self._db.execute("DELETE FROM cache WHERE key = ?", (key,))
-            self._db.commit()
-            return False
+        return self._lookup(key) is not None
 
     def get_path(self, key: str) -> str | None:
         """Return the cached file path for *key* if it exists, else None.
@@ -304,30 +507,11 @@ class ImageCache:
         Returns:
             Absolute path string to the cached file, or None.
         """
-        with self._access_lock:
-            row = self._db.execute(
-                "SELECT file_path FROM cache WHERE key = ?", (key,)
-            ).fetchone()
-            if row is None:
-                return None
-            cached_path = Path(row[0])
-            if not cached_path.exists():
-                # Remove stale DB entry when the underlying file is missing
-                self._db.execute(
-                    "DELETE FROM cache WHERE key = ?",
-                    (key,),
-                )
-                self._db.commit()
-                return None
-            self._db.execute(
-                "UPDATE cache "
-                "SET access_count = access_count + 1,"
-                "    last_accessed = ? "
-                "WHERE key = ?",
-                (time.time(), key),
-            )
-            self._db.commit()
-            return str(cached_path)
+        cached_path = self._lookup(key)
+        if cached_path is None:
+            return None
+        self._touch(key)
+        return str(cached_path)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -346,23 +530,14 @@ class ImageCache:
         Raises:
             IOError: If the copy or rename fails.
         """
-        tmp_path: str | None = None
+        fd, tmp_name = tempfile.mkstemp(dir=self.cache_path, suffix=".tmp")
+        os.close(fd)
+        tmp_path = Path(tmp_name)
         try:
-            with tempfile.NamedTemporaryFile(
-                mode="wb",
-                dir=self.cache_path,
-                delete=False,
-            ) as tmp_fh:
-                tmp_path = tmp_fh.name
-                with open(src, "rb") as src_fh:
-                    tmp_fh.write(src_fh.read())
+            shutil.copy2(src, tmp_path)
             os.replace(tmp_path, dst)
-        except IOError as exc:
-            if tmp_path is not None:
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
+        except OSError as exc:
+            tmp_path.unlink(missing_ok=True)
             raise IOError(f"Failed to cache file: {exc}") from exc
 
     def _generate_cache_filename(self, key: str, source_path: Path) -> str:
@@ -381,6 +556,7 @@ class ImageCache:
 
     def _evict_if_needed(self) -> None:
         """Evict LRU entries until cache size is at 90 % of the limit."""
+        conn = self._get_conn()
         current_size = self._get_cache_size()
 
         if current_size <= self.max_size_bytes:
@@ -392,31 +568,43 @@ class ImageCache:
             f"({self.max_size_bytes} bytes). Evicting to {target_size} bytes"
         )
 
-        rows = self._db.execute(
+        rows = conn.execute(
             "SELECT key, file_path, size_bytes FROM cache ORDER BY last_accessed ASC"
         ).fetchall()
 
         keys_to_delete: list[str] = []
-        for key, file_path_str, size_bytes in rows:
+        for evict_key, file_path_str, size_bytes in rows:
             if current_size <= target_size:
                 break
-            file_path = Path(file_path_str)
+            # Acquire the per-key lock non-blocking: skip keys that are
+            # currently being served by another thread so we do not delete
+            # a file that a concurrent get() is about to return.
+            key_lock = self._get_key_lock(evict_key)
+            if not key_lock.acquire(blocking=False):
+                logger.debug(
+                    f"Skipping eviction of key '{evict_key}' "
+                    "(lock held by another thread)"
+                )
+                continue
             try:
+                file_path = Path(file_path_str)
                 if file_path.exists():
                     file_path.unlink()
                 current_size -= size_bytes
-                keys_to_delete.append(key)
-                logger.debug(f"Evicted cache entry for key '{key}'")
+                keys_to_delete.append(evict_key)
+                logger.debug(f"Evicted cache entry for key '{evict_key}'")
             except OSError as exc:
                 logger.warning(f"Failed to delete cache file: {exc}")
+            finally:
+                key_lock.release()
 
         if keys_to_delete:
             placeholders = ",".join("?" * len(keys_to_delete))
-            self._db.execute(
+            conn.execute(
                 f"DELETE FROM cache WHERE key IN ({placeholders})",
                 keys_to_delete,
             )
-            self._db.commit()
+            conn.commit()
 
     def _get_cache_size(self) -> int:
         """Return the total size of all cached entries in bytes.
@@ -424,14 +612,16 @@ class ImageCache:
         Returns:
             Total bytes recorded in the database.
         """
-        row = self._db.execute(
+        conn = self._get_conn()
+        row = conn.execute(
             "SELECT COALESCE(SUM(size_bytes), 0) FROM cache"
         ).fetchone()
         return int(row[0])
 
     def _validate_cache_files(self) -> None:
         """Remove DB entries whose files no longer exist on disk."""
-        rows = self._db.execute("SELECT key, file_path FROM cache").fetchall()
+        conn = self._get_conn()
+        rows = conn.execute("SELECT key, file_path FROM cache").fetchall()
 
         invalid_keys = [key for key, fp in rows if not Path(fp).exists()]
 
@@ -439,9 +629,9 @@ class ImageCache:
             return
 
         placeholders = ",".join("?" * len(invalid_keys))
-        self._db.execute(
+        conn.execute(
             f"DELETE FROM cache WHERE key IN ({placeholders})",
             invalid_keys,
         )
-        self._db.commit()
+        conn.commit()
         logger.debug(f"Removed {len(invalid_keys)} invalid cache entries")

--- a/client/ayon_ui_qt/image_cache.py
+++ b/client/ayon_ui_qt/image_cache.py
@@ -334,21 +334,23 @@ class ImageCache:
         Raises:
             IOError: If the copy or rename fails.
         """
-        fd, tmp_path = tempfile.mkstemp(dir=self.cache_path)
+        tmp_path: str | None = None
         try:
-            try:
-                with os.fdopen(fd, "wb") as tmp_fh:
-                    with open(src, "rb") as src_fh:
-                        tmp_fh.write(src_fh.read())
-            except Exception:
-                os.close(fd)
-                raise
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=self.cache_path,
+                delete=False,
+            ) as tmp_fh:
+                tmp_path = tmp_fh.name
+                with open(src, "rb") as src_fh:
+                    tmp_fh.write(src_fh.read())
             os.replace(tmp_path, dst)
         except IOError as exc:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
             raise IOError(f"Failed to cache file: {exc}") from exc
 
     def _generate_cache_filename(self, key: str, source_path: Path) -> str:

--- a/client/ayon_ui_qt/image_cache.py
+++ b/client/ayon_ui_qt/image_cache.py
@@ -15,6 +15,8 @@ from typing import Callable
 
 logger = logging.getLogger(__name__)
 
+_DB_FILENAME = "cache_metadata.db"
+
 _CREATE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS cache (
     key           TEXT PRIMARY KEY,
@@ -181,7 +183,7 @@ class ImageCache:
         )
         self.cache_path.mkdir(parents=True, exist_ok=True)
 
-        self._db_path = self.cache_path / "cache_metadata.db"
+        self._db_path = self.cache_path / _DB_FILENAME
 
         # Per-thread connection storage.
         self._local = threading.local()
@@ -221,6 +223,8 @@ class ImageCache:
         count = 0
         for entry in os.scandir(self.cache_path):
             if entry.is_file() and entry.name != self._db_path.name:
+                if _DB_FILENAME in entry.path:
+                    continue
                 try:
                     os.remove(entry.path)
                     count += 1

--- a/client/ayon_ui_qt/image_cache.py
+++ b/client/ayon_ui_qt/image_cache.py
@@ -107,8 +107,35 @@ class ImageCache:
             cache_path: Directory path for storing cached files.
             max_size_in_MB: Maximum cache size in megabytes.
         """
-        raw_size = os.environ.get("AYON_IMG_CACHE_SIZE", max_size_in_MB)
-        self.max_size_in_MB = int(raw_size)
+        raw_size_env = os.environ.get("AYON_IMG_CACHE_SIZE")
+        if raw_size_env is not None:
+            try:
+                parsed_size = int(raw_size_env)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Environment variable AYON_IMG_CACHE_SIZE must be an integer "
+                    f"number of megabytes, got {raw_size_env!r}"
+                ) from exc
+            if parsed_size <= 0:
+                raise ValueError(
+                    f"Environment variable AYON_IMG_CACHE_SIZE must be a positive "
+                    f"integer number of megabytes, got {raw_size_env!r}"
+                )
+            self.max_size_in_MB = parsed_size
+        else:
+            try:
+                parsed_size = int(max_size_in_MB)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"max_size_in_MB must be an integer number of megabytes, "
+                    f"got {max_size_in_MB!r}"
+                ) from exc
+            if parsed_size <= 0:
+                raise ValueError(
+                    f"max_size_in_MB must be a positive integer number of "
+                    f"megabytes, got {max_size_in_MB!r}"
+                )
+            self.max_size_in_MB = parsed_size
         self.max_size_bytes = self.max_size_in_MB * 1024 * 1024
 
         self.cache_path = (

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -75,9 +75,11 @@ def test_get_cache_miss(cache: ImageCache, src_dir: Path) -> None:
 
     assert len(calls) == 1
     assert Path(result).exists()
-    row = cache._get_conn().execute(
-        "SELECT file_path FROM cache WHERE key = ?", ("key1",)
-    ).fetchone()
+    row = (
+        cache._get_conn()
+        .execute("SELECT file_path FROM cache WHERE key = ?", ("key1",))
+        .fetchone()
+    )
     assert row is not None
     assert Path(row[0]) == Path(result)
 
@@ -147,15 +149,19 @@ def test_get_path_returns_path(cache: ImageCache, src_dir: Path) -> None:
     src = _make_source_file(src_dir)
     cache.get("key1", lambda: src)
 
-    before = cache._get_conn().execute(
-        "SELECT access_count FROM cache WHERE key = ?", ("key1",)
-    ).fetchone()[0]
+    before = (
+        cache._get_conn()
+        .execute("SELECT access_count FROM cache WHERE key = ?", ("key1",))
+        .fetchone()[0]
+    )
 
     result = cache.get_path("key1")
 
-    after = cache._get_conn().execute(
-        "SELECT access_count FROM cache WHERE key = ?", ("key1",)
-    ).fetchone()[0]
+    after = (
+        cache._get_conn()
+        .execute("SELECT access_count FROM cache WHERE key = ?", ("key1",))
+        .fetchone()[0]
+    )
 
     assert result is not None
     assert Path(result).exists()
@@ -221,9 +227,11 @@ def test_validate_cache_files(cache_dir: Path, src_dir: Path) -> None:
     # Re-open — _validate_cache_files() runs in _initialize()
     ic2 = _fresh_cache(cache_dir)
     try:
-        row = ic2._get_conn().execute(
-            "SELECT key FROM cache WHERE key = ?", ("key1",)
-        ).fetchone()
+        row = (
+            ic2._get_conn()
+            .execute("SELECT key FROM cache WHERE key = ?", ("key1",))
+            .fetchone()
+        )
         assert row is None
     finally:
         ic2._close_all_connections()

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -11,7 +11,7 @@ from typing import Iterator
 
 import pytest
 
-from ayon_ui_qt.image_cache import ImageCache
+from ayon_ui_qt.image_cache import ImageCache, _DB_FILENAME
 
 
 # ---------------------------------------------------------------------------
@@ -354,3 +354,31 @@ def test_concurrent_processes(cache_dir: Path, src_dir: Path) -> None:
         assert len(keys) == 4, f"Expected 4 entries, got {len(keys)}"
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# test AYON_IMG_CACHE_CLEAR_ON_STARTUP
+# ---------------------------------------------------------------------------
+
+
+def test_clear_on_startup(cache_dir: Path, src_dir: Path) -> None:
+    """If AYON_IMG_CACHE_CLEAR_ON_STARTUP is set, cache files are deleted on init."""
+    # Create some dummy cache files
+    for i in range(5):
+        _make_source_file(src_dir, name=f"src_{i}.png")
+
+    # Set the environment variable and re-initialize the cache
+    import os
+
+    os.environ["AYON_IMG_CACHE_CLEAR_ON_STARTUP"] = "1"
+    ic = _fresh_cache(cache_dir)
+    try:
+        # Only the DB file should remain
+        remaining_files = list(cache_dir.iterdir())
+        assert all(_DB_FILENAME in f.name for f in remaining_files), (
+            f"Unexpected files in cache: {remaining_files}. "
+            f"Only {_DB_FILENAME}[-wal, -shm] should remain after clear "
+            "on startup"
+        )
+    finally:
+        ic._close_all_connections()

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -1,0 +1,357 @@
+"""Tests for ImageCache (SQLite backend)."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from ayon_ui_qt.image_cache import ImageCache
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_source_file(directory: Path, name: str = "src.png") -> Path:
+    """Write a tiny source image file and return its path."""
+    p = directory / name
+    p.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    return p
+
+
+def _fresh_cache(tmp_path: Path, max_mb: int = 10) -> ImageCache:
+    """Create an ImageCache instance that bypasses the singleton."""
+    instance = object.__new__(ImageCache)
+    instance._initialize(tmp_path, max_mb)
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cache_dir(tmp_path: Path) -> Path:
+    return tmp_path / "cache"
+
+
+@pytest.fixture
+def src_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "sources"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def cache(cache_dir: Path) -> Iterator[ImageCache]:
+    ic = _fresh_cache(cache_dir)
+    yield ic
+    ic._db.close()
+
+
+# ---------------------------------------------------------------------------
+# Basic get() behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_get_cache_miss(cache: ImageCache, src_dir: Path) -> None:
+    """file_closure is called on miss; file lands in cache; DB has an entry."""
+    src = _make_source_file(src_dir)
+    calls: list[int] = []
+
+    def closure() -> Path:
+        calls.append(1)
+        return src
+
+    result = cache.get("key1", closure)
+
+    assert len(calls) == 1
+    assert Path(result).exists()
+    row = cache._db.execute(
+        "SELECT file_path FROM cache WHERE key = ?", ("key1",)
+    ).fetchone()
+    assert row is not None
+    assert Path(row[0]) == Path(result)
+
+
+def test_get_cache_hit(cache: ImageCache, src_dir: Path) -> None:
+    """Second get() for the same key does NOT call file_closure again."""
+    src = _make_source_file(src_dir)
+    calls: list[int] = []
+
+    def closure() -> Path:
+        calls.append(1)
+        return src
+
+    first = cache.get("key1", closure)
+    second = cache.get("key1", closure)
+
+    assert len(calls) == 1
+    assert first == second
+
+
+def test_get_missing_file_reloads(cache: ImageCache, src_dir: Path) -> None:
+    """If the cached file is deleted from disk, get() re-caches it."""
+    src = _make_source_file(src_dir)
+    calls: list[int] = []
+
+    def closure() -> Path:
+        calls.append(1)
+        return src
+
+    first = cache.get("key1", closure)
+    Path(first).unlink()
+
+    second = cache.get("key1", closure)
+
+    assert len(calls) == 2
+    assert Path(second).exists()
+
+
+# ---------------------------------------------------------------------------
+# has()
+# ---------------------------------------------------------------------------
+
+
+def test_has_returns_true(cache: ImageCache, src_dir: Path) -> None:
+    src = _make_source_file(src_dir)
+    cache.get("key1", lambda: src)
+    assert cache.has("key1") is True
+
+
+def test_has_returns_false(cache: ImageCache) -> None:
+    assert cache.has("nonexistent") is False
+
+
+def test_has_missing_file(cache: ImageCache, src_dir: Path) -> None:
+    src = _make_source_file(src_dir)
+    cached = cache.get("key1", lambda: src)
+    Path(cached).unlink()
+    assert cache.has("key1") is False
+
+
+# ---------------------------------------------------------------------------
+# get_path()
+# ---------------------------------------------------------------------------
+
+
+def test_get_path_returns_path(cache: ImageCache, src_dir: Path) -> None:
+    src = _make_source_file(src_dir)
+    cache.get("key1", lambda: src)
+
+    before = cache._db.execute(
+        "SELECT access_count FROM cache WHERE key = ?", ("key1",)
+    ).fetchone()[0]
+
+    result = cache.get_path("key1")
+
+    after = cache._db.execute(
+        "SELECT access_count FROM cache WHERE key = ?", ("key1",)
+    ).fetchone()[0]
+
+    assert result is not None
+    assert Path(result).exists()
+    assert after == before + 1
+
+
+def test_get_path_returns_none(cache: ImageCache) -> None:
+    assert cache.get_path("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# Eviction
+# ---------------------------------------------------------------------------
+
+
+def test_eviction_lru(cache_dir: Path, src_dir: Path) -> None:
+    """Oldest-accessed entries are evicted first when the cache is full."""
+    # 1 MB max; each fake file is ~600 KB → two fit, third triggers eviction
+    ic = _fresh_cache(cache_dir, max_mb=1)
+    try:
+        chunk = b"\x00" * (600 * 1024)
+
+        def make_src(name: str) -> Path:
+            p = src_dir / name
+            p.write_bytes(chunk)
+            return p
+
+        # key_a is accessed earliest
+        src_a = make_src("a.bin")
+        src_b = make_src("b.bin")
+        src_c = make_src("c.bin")
+
+        ic.get("key_a", lambda: src_a)
+        time.sleep(0.01)
+        ic.get("key_b", lambda: src_b)
+        time.sleep(0.01)
+        # Adding key_c pushes total > 1 MB → key_a should be evicted
+        ic.get("key_c", lambda: src_c)
+
+        assert not ic.has("key_a"), "key_a should have been evicted"
+        assert ic.has("key_b") or ic.has("key_c"), (
+            "At least one recent entry must survive"
+        )
+    finally:
+        ic._db.close()
+
+
+# ---------------------------------------------------------------------------
+# _validate_cache_files()
+# ---------------------------------------------------------------------------
+
+
+def test_validate_cache_files(cache_dir: Path, src_dir: Path) -> None:
+    """Startup validation removes DB rows whose files are gone."""
+    ic = _fresh_cache(cache_dir)
+    src = _make_source_file(src_dir)
+    cached = ic.get("key1", lambda: src)
+    ic._db.close()
+
+    # Delete the file while the cache is "down"
+    Path(cached).unlink()
+
+    # Re-open — _validate_cache_files() runs in _initialize()
+    ic2 = _fresh_cache(cache_dir)
+    try:
+        row = ic2._db.execute(
+            "SELECT key FROM cache WHERE key = ?", ("key1",)
+        ).fetchone()
+        assert row is None
+    finally:
+        ic2._db.close()
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_empty_key_raises(cache: ImageCache) -> None:
+    with pytest.raises(ValueError, match="empty"):
+        cache.get("", lambda: Path("/nonexistent"))
+
+
+def test_invalid_closure_raises(cache: ImageCache) -> None:
+    with pytest.raises(ValueError, match="non-existent"):
+        cache.get("key1", lambda: Path("/does/not/exist.png"))
+
+
+# ---------------------------------------------------------------------------
+# Atomic file write
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_file_write(cache: ImageCache, src_dir: Path) -> None:
+    """Cached file must be complete (not a partial write)."""
+    content = b"\x89PNG\r\n\x1a\n" + b"\xab" * 1024
+    src = src_dir / "real.png"
+    src.write_bytes(content)
+
+    result = cache.get("key1", lambda: src)
+
+    assert Path(result).read_bytes() == content
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_threads(cache: ImageCache, src_dir: Path) -> None:
+    """Multiple threads calling get() simultaneously must not corrupt the DB."""
+    src = _make_source_file(src_dir)
+    results: list[str] = []
+    errors: list[Exception] = []
+
+    def worker(idx: int) -> None:
+        try:
+            path = cache.get(f"key{idx % 3}", lambda: src)
+            results.append(path)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Thread errors: {errors}"
+    assert len(results) == 20
+    # DB must be consistent — no duplicate keys
+    rows = cache._db.execute("SELECT key FROM cache").fetchall()
+    keys = [r[0] for r in rows]
+    assert len(keys) == len(set(keys))
+
+
+# ---------------------------------------------------------------------------
+# Legacy JSON cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_json_cleanup(cache_dir: Path) -> None:
+    """Old cache_metadata.json (and .lock) are deleted on initialisation."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    legacy_json = cache_dir / "cache_metadata.json"
+    legacy_lock = cache_dir / "cache_metadata.json.lock"
+    legacy_json.write_text('{"old": "data"}')
+    legacy_lock.write_text("")
+
+    ic = _fresh_cache(cache_dir)
+    try:
+        assert not legacy_json.exists()
+        assert not legacy_lock.exists()
+    finally:
+        ic._db.close()
+
+
+# ---------------------------------------------------------------------------
+# Concurrent processes
+# ---------------------------------------------------------------------------
+
+
+def _worker_process(cache_dir: str, key: str, src_file: str) -> None:
+    """Target function for subprocess workers."""
+    ic = _fresh_cache(Path(cache_dir))
+    ic.get(key, lambda: Path(src_file))
+    ic._db.close()
+
+
+def test_concurrent_processes(cache_dir: Path, src_dir: Path) -> None:
+    """Multiple processes writing to the same cache must leave a valid DB."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    src = _make_source_file(src_dir)
+
+    procs = [
+        multiprocessing.Process(
+            target=_worker_process,
+            args=(str(cache_dir), f"proc_key_{i}", str(src)),
+        )
+        for i in range(4)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+
+    for p in procs:
+        assert p.exitcode == 0, f"Process exited with {p.exitcode}"
+
+    # Verify DB integrity after all processes have written
+    conn = sqlite3.connect(str(cache_dir / "cache_metadata.db"))
+    try:
+        rows = conn.execute("SELECT key FROM cache").fetchall()
+        keys = [r[0] for r in rows]
+        assert len(keys) == len(set(keys)), "Duplicate keys in DB"
+        assert len(keys) == 4, f"Expected 4 entries, got {len(keys)}"
+    finally:
+        conn.close()

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import multiprocessing
-import os
 import sqlite3
 import threading
 import time

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -54,7 +54,7 @@ def src_dir(tmp_path: Path) -> Path:
 def cache(cache_dir: Path) -> Iterator[ImageCache]:
     ic = _fresh_cache(cache_dir)
     yield ic
-    ic._db.close()
+    ic._close_all_connections()
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +75,7 @@ def test_get_cache_miss(cache: ImageCache, src_dir: Path) -> None:
 
     assert len(calls) == 1
     assert Path(result).exists()
-    row = cache._db.execute(
+    row = cache._get_conn().execute(
         "SELECT file_path FROM cache WHERE key = ?", ("key1",)
     ).fetchone()
     assert row is not None
@@ -147,13 +147,13 @@ def test_get_path_returns_path(cache: ImageCache, src_dir: Path) -> None:
     src = _make_source_file(src_dir)
     cache.get("key1", lambda: src)
 
-    before = cache._db.execute(
+    before = cache._get_conn().execute(
         "SELECT access_count FROM cache WHERE key = ?", ("key1",)
     ).fetchone()[0]
 
     result = cache.get_path("key1")
 
-    after = cache._db.execute(
+    after = cache._get_conn().execute(
         "SELECT access_count FROM cache WHERE key = ?", ("key1",)
     ).fetchone()[0]
 
@@ -200,7 +200,7 @@ def test_eviction_lru(cache_dir: Path, src_dir: Path) -> None:
             "At least one recent entry must survive"
         )
     finally:
-        ic._db.close()
+        ic._close_all_connections()
 
 
 # ---------------------------------------------------------------------------
@@ -213,7 +213,7 @@ def test_validate_cache_files(cache_dir: Path, src_dir: Path) -> None:
     ic = _fresh_cache(cache_dir)
     src = _make_source_file(src_dir)
     cached = ic.get("key1", lambda: src)
-    ic._db.close()
+    ic._close_all_connections()
 
     # Delete the file while the cache is "down"
     Path(cached).unlink()
@@ -221,12 +221,12 @@ def test_validate_cache_files(cache_dir: Path, src_dir: Path) -> None:
     # Re-open — _validate_cache_files() runs in _initialize()
     ic2 = _fresh_cache(cache_dir)
     try:
-        row = ic2._db.execute(
+        row = ic2._get_conn().execute(
             "SELECT key FROM cache WHERE key = ?", ("key1",)
         ).fetchone()
         assert row is None
     finally:
-        ic2._db.close()
+        ic2._close_all_connections()
 
 
 # ---------------------------------------------------------------------------
@@ -287,7 +287,7 @@ def test_concurrent_threads(cache: ImageCache, src_dir: Path) -> None:
     assert not errors, f"Thread errors: {errors}"
     assert len(results) == 20
     # DB must be consistent — no duplicate keys
-    rows = cache._db.execute("SELECT key FROM cache").fetchall()
+    rows = cache._get_conn().execute("SELECT key FROM cache").fetchall()
     keys = [r[0] for r in rows]
     assert len(keys) == len(set(keys))
 
@@ -310,7 +310,7 @@ def test_legacy_json_cleanup(cache_dir: Path) -> None:
         assert not legacy_json.exists()
         assert not legacy_lock.exists()
     finally:
-        ic._db.close()
+        ic._close_all_connections()
 
 
 # ---------------------------------------------------------------------------
@@ -322,7 +322,7 @@ def _worker_process(cache_dir: str, key: str, src_file: str) -> None:
     """Target function for subprocess workers."""
     ic = _fresh_cache(Path(cache_dir))
     ic.get(key, lambda: Path(src_file))
-    ic._db.close()
+    ic._close_all_connections()
 
 
 def test_concurrent_processes(cache_dir: Path, src_dir: Path) -> None:


### PR DESCRIPTION
## Changelog Description

Replace JSON metadata with SQLite for concurrent access

Migrate cache metadata from JSON file storage to SQLite database to enable safe concurrent access across multiple processes. The new implementation uses WAL journal mode and busy_timeout settings to handle simultaneous connections from different AYON instances without data corruption.

Key changes:
- Add SQLite database schema for tracking cache entries with access patterns
- Implement thread-safe database operations using connection pooling
- Replace JSON serialization with direct SQL queries for metadata management
- Maintain LRU eviction policy through last_accessed timestamp indexing
- Preserve existing disk storage for cached image files

The SQLite backend provides ACID compliance and eliminates race conditions that could occur when multiple processes attempt to update cache metadata concurrently, improving reliability in multi-instance deployment scenarios.

## Additional review information

This should be a plug-n-play replacement as the API hasn't changed.

## Testing notes:
1. start with this step
2. follow this step
