### PR TITLE
fix(table): prevent crash on model reset with active hover state

### DIFF
--- a/client/ayon_ui_qt/components/table_view.py
+++ b/client/ayon_ui_qt/components/table_view.py
@@ -701,6 +701,8 @@ class AYTableView(QTreeView):
         from a clean slate, then schedules a sync so visible rows get their
         editors back.
         """
+        self._hovered_index = QModelIndex()
+        self._hovered_row = -1
         self._active_editor_pmis.clear()
         self._schedule_editor_sync()
 

--- a/client/ayon_ui_qt/components/table_view.py
+++ b/client/ayon_ui_qt/components/table_view.py
@@ -703,6 +703,7 @@ class AYTableView(QTreeView):
         """
         self._hovered_index = QModelIndex()
         self._hovered_row = -1
+        self._hovered_row_rect = QRect()
         self._active_editor_pmis.clear()
         self._schedule_editor_sync()
 


### PR DESCRIPTION
## Changelog Description
Initialize hover state variables when resetting model to avoid reference to stale QModelIndex after model changes. The crash occurred when the table view maintained hover state references to indices that became invalid after model reset.

This ensures the hover system starts from a clean state alongside the editor system during model reset operations.

## Additional review information
None

## Testing notes:
1. Opene browser
2. select another item in the slice and immediately hover over the table.
3. nothing should happen except the expected hover effect.
