### PR TITLE
fix_comment_checklist_and_update_comment_tag

### DIFF
--- a/client/ayon_ui_qt/components/checkbox_handler.py
+++ b/client/ayon_ui_qt/components/checkbox_handler.py
@@ -43,7 +43,7 @@ CHECKED_COLOR = "#4CAF50"
 
 MD_DIALECT = QTextDocument.MarkdownFeature.MarkdownDialectGitHub
 
-_PH_RE = re.compile(r"^\s*\ufffc ")  # place holder regex
+_PH_RE = re.compile(r"[*_`]+$")
 
 
 @dataclass
@@ -547,12 +547,12 @@ class CheckboxHandler(QObject):
 
         for line in lines:
             if "\ufffc" in line and current_cb:
-                # Replace "  \ufffc " with prefix + checkbox syntax
                 checked_char = "x" if current_cb.checked else " "
-                # Remove the spaces before \ufffc and add the proper prefix
-                line = _PH_RE.sub(
-                    f"{current_cb.prefix}[{checked_char}] ", line, count=1
-                )
+                cb_idx = line.index("\ufffc")
+                raw_after = line[cb_idx + 1:]       # everything after \ufffc
+                raw_after = raw_after.lstrip(" ")    # drop the space Qt inserts
+                raw_after = _PH_RE.sub("", raw_after).rstrip()
+                line = f"{current_cb.prefix}[{checked_char}] {raw_after}"
                 current_cb = next(checkbox_iter, None)
             result_lines.append(line)
 

--- a/client/ayon_ui_qt/components/comment.py
+++ b/client/ayon_ui_qt/components/comment.py
@@ -980,7 +980,7 @@ class AYComment(AYContainer):
             variant=AYCommentField.Variants.High,
         )
 
-        editor_lyt = AYContainer(
+        self.editor_lyt = AYContainer(
             layout=AYContainer.Layout.VBox,
             variant=AYContainer.Variants.High,
             bg_tint=self._data.category_color,
@@ -1000,12 +1000,23 @@ class AYComment(AYContainer):
         )
         self.images_container.setContentsMargins(0, 0, 0, 0)
         self.top_line.setFixedHeight(20)
-        editor_lyt.add_widget(self.top_line, stretch=0)
-        editor_lyt.add_widget(self.images_container, stretch=0)
-        editor_lyt.add_widget(self.text_field, stretch=10)
 
-        editor_lyt.add_layout(self._build_editor_toolbar(), stretch=0)
-        self.add_widget(editor_lyt)
+        # Create comment category once — hidden until a category is set
+        self.comment_category = AYLabel(
+            "",
+            icon_color="",
+            variant=AYLabel.Variants.Badge,
+            rel_text_size=-2,
+        )
+        self.comment_category.setVisible(False)
+        self.top_line.insert_widget(0, self.comment_category)
+
+        self.editor_lyt.add_widget(self.top_line, stretch=0)
+        self.editor_lyt.add_widget(self.images_container, stretch=0)
+        self.editor_lyt.add_widget(self.text_field, stretch=10)
+
+        self.editor_lyt.add_layout(self._build_editor_toolbar(), stretch=0)
+        self.add_widget(self.editor_lyt)
         self._build_edit_buttons()
 
     def _build_image_attachments(self):
@@ -1139,15 +1150,30 @@ class AYComment(AYContainer):
             self.edit_frame.move((vr.width() + vr.x()) - fr.width(), 0)
 
     def set_comment_category(self):
+        """Update the comment category and comment background tint"""
+        self._update_category_bg_tint()
+
         if not self._data.category:
+            self.comment_category.setVisible(False)
             return
-        cat = AYLabel(
-            self._data.category,
-            icon_color=self._data.category_color,
-            variant=AYLabel.Variants.Badge,
-            rel_text_size=-2,
-        )
-        self.top_line.insert_widget(0, cat)
+
+        # Update comment category
+        self.comment_category.setText(self._data.category)
+        self.comment_category.set_icon_color(self._data.category_color)
+        self.comment_category.setVisible(True)
+
+    def _update_category_bg_tint(self):
+        """Update bg_tint on containers that use category_color."""
+        tint = self._data.category_color or ""
+        for widget in (
+            self.editor_lyt,
+            self.top_line,
+            self.images_container,
+            self.edit_frame,
+        ):
+            widget._bg_tint = tint
+            widget._bg_color = None  # reset cache so it recalculates
+            widget.update()  # trigger repaint
 
     def enterEvent(self, event: QEnterEvent) -> None:
         self._show_edit_buttons(True)

--- a/client/ayon_ui_qt/components/label.py
+++ b/client/ayon_ui_qt/components/label.py
@@ -808,6 +808,20 @@ class AYLabel(QtWidgets.QLabel):
         super().setText(arg__1)
         self._text = self.text()
 
+    def set_icon_color(self, color: str) -> None:
+        """Update the icon color and refresh the widget.
+
+        Resets contrast color cache so Badge background fill and text
+        contrast are recalculated with the new color.
+
+        Args:
+            color: New hex color string e.g. '#44ee9f'.
+        """
+        self._icon_color = color
+        self._contrast_color = None  # reset so _configure_palette recalculates
+        self.set_icon(color=color)   # repaints icon pixmap with new color
+        self.update()                # triggers paintEvent -> _configure_palette
+
     def palette(self) -> QPalette:
         return QPalette(self._style_palette)
 

--- a/client/ayon_ui_qt/components/label.py
+++ b/client/ayon_ui_qt/components/label.py
@@ -811,16 +811,18 @@ class AYLabel(QtWidgets.QLabel):
     def set_icon_color(self, color: str) -> None:
         """Update the icon color and refresh the widget.
 
-        Resets contrast color cache so Badge background fill and text
-        contrast are recalculated with the new color.
+        Resets contrast color cache so filled variants (e.g. Badge) and any
+        palette-based contrast logic are recalculated with the new color.
 
         Args:
             color: New hex color string e.g. '#44ee9f'.
         """
         self._icon_color = color
-        self._contrast_color = None  # reset so _configure_palette recalculates
+        self._contrast_color = None  # reset so contrast is recalculated
+        self._configure_palette()
         self.set_icon(color=color)   # repaints icon pixmap with new color
-        self.update()                # triggers paintEvent -> _configure_palette
+        self._copy_pix_normal = self._copy_pix_hover = self._copy_pix_done = None
+        self.update()
 
     def palette(self) -> QPalette:
         return QPalette(self._style_palette)


### PR DESCRIPTION
## Changelog Description

- checkbox_handler.py - match \ufffc placeholder position correctly in to_markdown
- label.py - Added set_icon_color to AYLabel as it used as tag on commet instead of creating new everytime on update not it updates color with this
- comment.py - creating comment category at time of building comment and hiding it so that can unhide/reuse/update/ when needed, When comment is updating, update the tag and bg color with respective tag

## Additional review information
checkbox_handler.py to_markdown() used a regex anchored to the start of the line (^\s*\ufffc) to locate the checkbox placeholder. Qt's toMarkdown() outputs - \ufffc text — the list prefix comes before \ufffc, so the regex never matched and lines were left with raw \ufffc on save. Fixed by using str.index() to find the placeholder at any position, slicing the label text after it, stripping Qt's injected space and any trailing markdown artifacts (`*_\``).

label.py Added set_icon_color(color: str) method to AYLabel. It updates _icon_color, resets the contrast color cache, repaints the icon pixmap, and calls update(). This allows callers to change the tag color without destroying and recreating the widget.

comment.py Previously, the comment category tag widget was created and destroyed on every comment update, causing flicker and unnecessary allocations. Now all possible category tag widgets are created once during the comment widget's __init__ and hidden. When a comment is rendered or updated, the correct tag is shown and its text/background color updated via set_icon_color() — no widget recreation needed.

## Testing notes:
- Open activity panel in OpenRV and see comment tag change from web it reflecting here and colour updating accordingly
- Add checklists and comment