### PR TITLE
fix(ui): schedule editor sync on resize in card and table views

### DIFF
--- a/client/ayon_ui_qt/components/card_view.py
+++ b/client/ayon_ui_qt/components/card_view.py
@@ -785,6 +785,7 @@ class AYCardView(QAbstractItemView):
         super().resizeEvent(event)
         self._calculate_layout()
         self._reposition_visible_editors()
+        self._schedule_editor_sync()
 
     def paintEvent(self, event: QPaintEvent) -> None:
         painter = QPainter(self.viewport())

--- a/client/ayon_ui_qt/components/table_view.py
+++ b/client/ayon_ui_qt/components/table_view.py
@@ -790,6 +790,21 @@ class AYTableView(StyleMixin, QTreeView):
                 self.openPersistentEditor(pmi)
                 self._active_editor_pmis.add(pmi)
 
+    def resizeEvent(self, event: Any) -> None:  # type: ignore[override]
+        """Schedule an editor sync when the view is resized.
+
+        A viewport resize may reveal rows that have never been visible
+        before.  Those rows need ``openPersistentEditor`` called on them
+        before their thumbnail widgets can be created and painted.  The
+        regular scroll-driven sync misses this case because the scrollbar
+        value does not change on a pure resize.
+
+        Args:
+            event: The resize event.
+        """
+        super().resizeEvent(event)
+        self._schedule_editor_sync()
+
     def mousePressEvent(  # type: ignore[override]
         self, event: "QtGui.QMouseEvent"
     ) -> None:


### PR DESCRIPTION
## Changelog Description
Ensure that persistent editors are synchronized when the view is resized. A viewport resize can reveal rows that were previously hidden, requiring `openPersistentEditor` to be called so that their thumbnail widgets can be correctly created and painted. This addresses cases where a pure resize (without scrollbar movement) would otherwise miss these rows.

## Testing notes:
1. start with this step
2. follow this step
