### PR TITLE
fix(task-queue): prevent redundant aboutToQuit connections

### DIFF
--- a/client/ayon_ui_qt/components/task_queue.py
+++ b/client/ayon_ui_qt/components/task_queue.py
@@ -636,6 +636,7 @@ class AsyncTaskQueue(QThread):
 # ---------------------------------------------------------------------------
 
 _shared_queue: AsyncTaskQueue | None = None
+_shutdown_connected: bool = False
 
 
 def get_task_queue() -> AsyncTaskQueue:
@@ -651,7 +652,7 @@ def get_task_queue() -> AsyncTaskQueue:
     Returns:
         The running shared :class:`AsyncTaskQueue` instance.
     """
-    global _shared_queue
+    global _shared_queue, _shutdown_connected
     if _shared_queue is None:
         from qtpy.QtWidgets import QApplication  # local import avoids circular
 
@@ -661,14 +662,9 @@ def get_task_queue() -> AsyncTaskQueue:
 
         app = QApplication.instance()
         if app is not None:
-            # Guard: connect at most once to avoid accumulating
-            # connections during test runs where the queue is
-            # repeatedly created and destroyed.
-            try:
-                app.aboutToQuit.disconnect(shutdown_task_queue)
-            except RuntimeError:
-                pass  # was not connected yet
-            app.aboutToQuit.connect(shutdown_task_queue)
+            if not _shutdown_connected:
+                app.aboutToQuit.connect(shutdown_task_queue)
+                _shutdown_connected = True
         else:
             log.warning(
                 "get_task_queue() called before QApplication exists; "


### PR DESCRIPTION
## Changelog Description
Replace the try-except disconnect pattern with a boolean flag `_shutdown_connected` to track whether the `shutdown_task_queue` signal has been connected to `QApplication.aboutToQuit`. This ensures the connection is made exactly once and avoids potential RuntimeErrors during repeated queue initialization.


## Testing notes:
1. launch browser
2. no more warning:
```
RuntimeWarning: Failed to disconnect (<function shutdown_task_queue at 0x117bf61f0>) from signal "aboutToQuit()".
  app.aboutToQuit.disconnect(shutdown_task_queue)
```
